### PR TITLE
[REFACTOR] 자바 표준 예외를 커스텀 예외로 통일

### DIFF
--- a/src/main/java/com/debatetimer/config/AuthMemberArgumentResolver.java
+++ b/src/main/java/com/debatetimer/config/AuthMemberArgumentResolver.java
@@ -32,7 +32,7 @@ public class AuthMemberArgumentResolver implements HandlerMethodArgumentResolver
             WebDataBinderFactory binderFactory
     ) {
         try {
-            Long memberId = Long.parseLong(webRequest.getParameter("memberId"));
+            long memberId = Long.parseLong(webRequest.getParameter("memberId"));
             return memberRepository.getById(memberId);
         } catch (DTException | NumberFormatException exception) {
             log.warn(exception.getMessage());

--- a/src/main/java/com/debatetimer/domain/member/Member.java
+++ b/src/main/java/com/debatetimer/domain/member/Member.java
@@ -1,5 +1,7 @@
 package com.debatetimer.domain.member;
 
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,10 +33,10 @@ public class Member {
 
     private void validate(String nickname) {
         if (nickname.isEmpty() || nickname.length() > NICKNAME_MAX_LENGTH) {
-            throw new IllegalArgumentException("닉네임은 1자 이상 %d자 이하여야 합니다".formatted(NICKNAME_MAX_LENGTH));
+            throw new DTClientErrorException(ClientErrorCode.INVALID_MEMBER_NICKNAME_LENGTH);
         }
         if (!nickname.matches(NICKNAME_REGEX)) {
-            throw new IllegalArgumentException("닉네임은 영문/한글만 가능합니다");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_MEMBER_NICKNAME_FORM);
         }
     }
 }

--- a/src/main/java/com/debatetimer/domain/parliamentary/ParliamentaryTable.java
+++ b/src/main/java/com/debatetimer/domain/parliamentary/ParliamentaryTable.java
@@ -1,6 +1,8 @@
 package com.debatetimer.domain.parliamentary;
 
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -50,13 +52,13 @@ public class ParliamentaryTable {
 
     private void validate(String name, int duration) {
         if (name.isBlank() || name.length() > NAME_MAX_LENGTH) {
-            throw new IllegalArgumentException("테이블 이름은 1자 이상 %d자 이하여야 합니다".formatted(NAME_MAX_LENGTH));
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TABLE_NAME_LENGTH);
         }
         if (!name.matches(NAME_REGEX)) {
-            throw new IllegalArgumentException("테이블 이름은 영문/한글만 가능합니다");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TABLE_NAME_FORM);
         }
         if (duration <= 0) {
-            throw new IllegalArgumentException("시간은 양수만 가능합니다");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TABLE_TIME);
         }
     }
 

--- a/src/main/java/com/debatetimer/domain/parliamentary/ParliamentaryTimeBox.java
+++ b/src/main/java/com/debatetimer/domain/parliamentary/ParliamentaryTimeBox.java
@@ -2,6 +2,8 @@ package com.debatetimer.domain.parliamentary;
 
 import com.debatetimer.domain.BoxType;
 import com.debatetimer.domain.Stance;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -59,14 +61,14 @@ public class ParliamentaryTimeBox {
 
     private void validate(int sequence, int time, Stance stance, BoxType boxType) {
         if (sequence <= 0) {
-            throw new IllegalArgumentException("순서는 양수만 가능합니다");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_SEQUENCE);
         }
         if (time <= 0) {
-            throw new IllegalArgumentException("시간은 양수만 가능합니다");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
         }
 
         if (!boxType.isAvailable(stance)) {
-            throw new IllegalArgumentException("타임박스 유형과 일치하지 않는 입장입니다.");
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_STANCE);
         }
     }
 }

--- a/src/main/java/com/debatetimer/exception/custom/DTException.java
+++ b/src/main/java/com/debatetimer/exception/custom/DTException.java
@@ -8,7 +8,7 @@ public abstract class DTException extends RuntimeException {
 
     private final HttpStatus httpStatus;
 
-    public DTException(String message, HttpStatus httpStatus) {
+    protected DTException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }

--- a/src/main/java/com/debatetimer/exception/errorcode/ClientErrorCode.java
+++ b/src/main/java/com/debatetimer/exception/errorcode/ClientErrorCode.java
@@ -1,10 +1,32 @@
 package com.debatetimer.exception.errorcode;
 
+import com.debatetimer.domain.member.Member;
+import com.debatetimer.domain.parliamentary.ParliamentaryTable;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ClientErrorCode implements ErrorCode {
+
+    INVALID_MEMBER_NICKNAME_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "닉네임은 1자 이상 %d자 이하여야 합니다".formatted(Member.NICKNAME_MAX_LENGTH)
+    ),
+    INVALID_MEMBER_NICKNAME_FORM(HttpStatus.BAD_REQUEST, "닉네임은 영문/한글만 가능합니다"),
+
+    INVALID_TABLE_NAME_LENGTH(
+            HttpStatus.BAD_REQUEST,
+            "테이블 이름은 1자 이상 %d자 이하여야 합니다".formatted(ParliamentaryTable.NAME_MAX_LENGTH)
+    ),
+    INVALID_TABLE_NAME_FORM(
+            HttpStatus.BAD_REQUEST,
+            "테이블 이름은 영문/한글만 가능합니다"
+    ),
+    INVALID_TABLE_TIME(HttpStatus.BAD_REQUEST, "시간은 양수만 가능합니다"),
+
+    INVALID_TIME_BOX_SEQUENCE(HttpStatus.BAD_REQUEST, "순서는 양수만 가능합니다"),
+    INVALID_TIME_BOX_TIME(HttpStatus.BAD_REQUEST, "시간은 양수만 가능합니다"),
+    INVALID_TIME_BOX_STANCE(HttpStatus.BAD_REQUEST, "타임박스 유형과 일치하지 않는 입장입니다."),
 
     FIELD_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
     URL_PARAMETER_ERROR(HttpStatus.BAD_REQUEST, "입력이 잘못되었습니다."),
@@ -17,6 +39,8 @@ public enum ClientErrorCode implements ErrorCode {
     TABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "토론 테이블을 찾을 수 없습니다."),
     NOT_TABLE_OWNER(HttpStatus.UNAUTHORIZED, "테이블을 소유한 회원이 아닙니다."),
     UNAUTHORIZED_MEMBER(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원이 존재하지 않습니다"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/debatetimer/repository/member/MemberRepository.java
+++ b/src/main/java/com/debatetimer/repository/member/MemberRepository.java
@@ -1,12 +1,14 @@
 package com.debatetimer.repository.member;
 
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     default Member getById(long id) {
         return findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다"));
+                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/debatetimer/service/member/MemberService.java
+++ b/src/main/java/com/debatetimer/service/member/MemberService.java
@@ -20,7 +20,7 @@ public class MemberService {
     private final ParliamentaryTableRepository parliamentaryTableRepository;
 
     @Transactional(readOnly = true)
-    public TableResponses getTables(Long memberId) {
+    public TableResponses getTables(long memberId) {
         Member member = memberRepository.getById(memberId);
         List<ParliamentaryTable> parliamentaryTable = parliamentaryTableRepository.findAllByMember(member);
         return TableResponses.from(parliamentaryTable);

--- a/src/test/java/com/debatetimer/domain/member/MemberTest.java
+++ b/src/test/java/com/debatetimer/domain/member/MemberTest.java
@@ -3,6 +3,8 @@ package com.debatetimer.domain.member;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -23,16 +25,16 @@ class MemberTest {
         @ValueSource(ints = {0, Member.NICKNAME_MAX_LENGTH + 1})
         void 닉네임은_정해진_길이_이내여야_한다(int length) {
             assertThatThrownBy(() -> new Member("f".repeat(length)))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("닉네임은 1자 이상 %d자 이하여야 합니다".formatted(Member.NICKNAME_MAX_LENGTH));
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_MEMBER_NICKNAME_LENGTH.getMessage());
         }
 
         @ParameterizedTest
         @ValueSource(strings = {"abc12", "가나다12"})
         void 닉네임은_영문과_한글만_가능하다(String nickname) {
             assertThatThrownBy(() -> new Member(nickname))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("닉네임은 영문/한글만 가능합니다");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_MEMBER_NICKNAME_FORM.getMessage());
         }
     }
 }

--- a/src/test/java/com/debatetimer/domain/parliamentary/ParliamentaryTableTest.java
+++ b/src/test/java/com/debatetimer/domain/parliamentary/ParliamentaryTableTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -26,8 +28,8 @@ class ParliamentaryTableTest {
         void 테이블_이름은_정해진_길이_이내여야_한다(int length) {
             Member member = new Member("member");
             assertThatThrownBy(() -> new ParliamentaryTable(member, "f".repeat(length), "agenda", 10))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("테이블 이름은 1자 이상 %d자 이하여야 합니다".formatted(ParliamentaryTable.NAME_MAX_LENGTH));
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TABLE_NAME_LENGTH.getMessage());
         }
 
         @ParameterizedTest
@@ -35,8 +37,8 @@ class ParliamentaryTableTest {
         void 테이블_이름은_적어도_한_자_있어야_한다(String name) {
             Member member = new Member("member");
             assertThatThrownBy(() -> new ParliamentaryTable(member, name, "agenda", 10))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("테이블 이름은 1자 이상 %d자 이하여야 합니다".formatted(ParliamentaryTable.NAME_MAX_LENGTH));
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TABLE_NAME_LENGTH.getMessage());
         }
 
         @ParameterizedTest
@@ -44,8 +46,8 @@ class ParliamentaryTableTest {
         void 허용된_글자_이외의_문자는_불가능하다(String name) {
             Member member = new Member("member");
             assertThatThrownBy(() -> new ParliamentaryTable(member, name, "agenda", 10))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("테이블 이름은 영문/한글만 가능합니다");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TABLE_NAME_FORM.getMessage());
         }
 
         @ParameterizedTest
@@ -53,8 +55,8 @@ class ParliamentaryTableTest {
         void 테이블_시간은_양수만_가능하다(int duration) {
             Member member = new Member("member");
             assertThatThrownBy(() -> new ParliamentaryTable(member, "name", "agenda", duration))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("시간은 양수만 가능합니다");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TABLE_TIME.getMessage());
         }
     }
 }

--- a/src/test/java/com/debatetimer/domain/parliamentary/ParliamentaryTimeBoxTest.java
+++ b/src/test/java/com/debatetimer/domain/parliamentary/ParliamentaryTimeBoxTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.debatetimer.domain.BoxType;
 import com.debatetimer.domain.Stance;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -17,16 +19,16 @@ class ParliamentaryTimeBoxTest {
         void 순서는_양수만_가능하다() {
             ParliamentaryTable table = new ParliamentaryTable();
             assertThatThrownBy(() -> new ParliamentaryTimeBox(table, 0, Stance.CONS, BoxType.OPENING, 10, 1))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("순서는 양수만 가능합니다");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SEQUENCE.getMessage());
         }
 
         @Test
         void 시간은_양수만_가능하다() {
             ParliamentaryTable table = new ParliamentaryTable();
             assertThatThrownBy(() -> new ParliamentaryTimeBox(table, 1, Stance.CONS, BoxType.OPENING, 0, 1))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("시간은 양수만 가능합니다");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
         }
 
         @Test
@@ -40,8 +42,8 @@ class ParliamentaryTimeBoxTest {
         void 박스타입에_불가한_입장으로_생성을_시도하면_예외를_발생시킨다() {
             ParliamentaryTable table = new ParliamentaryTable();
             assertThatThrownBy(() -> new ParliamentaryTimeBox(table, 1, Stance.NEUTRAL, BoxType.OPENING, 10, 1))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("타임박스 유형과 일치하지 않는 입장입니다.");
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_STANCE.getMessage());
         }
     }
 }

--- a/src/test/java/com/debatetimer/repository/parliamentary/ParliamentaryTableRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/parliamentary/ParliamentaryTableRepositoryTest.java
@@ -43,7 +43,7 @@ class ParliamentaryTableRepositoryTest extends BaseRepositoryTest {
             Member chan = fixtureGenerator.generateMember("커찬");
             ParliamentaryTable chanTable = fixtureGenerator.generateParliamentaryTable(chan);
 
-            ParliamentaryTable foundChanTable = tableRepository.getById(chanTable.getId());
+            ParliamentaryTable foundChanTable = tableRepository.getById(chanTable.getId().longValue());
 
             assertThat(foundChanTable).usingRecursiveComparison().isEqualTo(chanTable);
         }


### PR DESCRIPTION
# 🚩 연관 이슈
closed #39 

# 🗣️ 리뷰 요구사항 (선택)
이번 수정사항 중 `Long`을 `long`으로 바꾼 것은 `JpaRepository`의 메소드 중에 `getById(Long id)`가 있습니다. 그래서 인자로 `Long`을 사용하면 해당 메소드가 사용됩니다. 그래서 매개변수에 전달할 값을 전부 `long`으로 수정했습니다.