### PR TITLE
[CHORE] 애플리케이션 에러로깅 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ configurations {
         extendsFrom annotationProcessor
     }
 
-    all {
+    configureEach {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
     }
 }
@@ -62,6 +62,7 @@ dependencies {
 
     // Logging
     implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
 }
 
 bootJar {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,10 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
 }
 
 repositories {
@@ -55,6 +59,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-gson:0.11.5'
+
+    // Logging
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 }
 
 bootJar {

--- a/src/main/java/com/debatetimer/client/OAuthClient.java
+++ b/src/main/java/com/debatetimer/client/OAuthClient.java
@@ -3,11 +3,13 @@ package com.debatetimer.client;
 import com.debatetimer.dto.member.MemberCreateRequest;
 import com.debatetimer.dto.member.MemberInfo;
 import com.debatetimer.dto.member.OAuthToken;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @EnableConfigurationProperties(OAuthProperties.class)
 public class OAuthClient {
@@ -21,19 +23,23 @@ public class OAuthClient {
     }
 
     public OAuthToken requestToken(MemberCreateRequest request) {
-        return restClient.post()
+        OAuthToken oAuthToken = restClient.post()
                 .uri("https://oauth2.googleapis.com/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(oauthProperties.createTokenRequestBody(request))
                 .retrieve()
                 .body(OAuthToken.class);
+        log.info("구글 액세스 토근 발급 성공");
+        return oAuthToken;
     }
 
     public MemberInfo requestMemberInfo(OAuthToken response) {
-        return restClient.get()
+        MemberInfo memberInfo = restClient.get()
                 .uri("https://www.googleapis.com/oauth2/v3/userinfo")
                 .headers(headers -> headers.setBearerAuth(response.access_token()))
                 .retrieve()
                 .body(MemberInfo.class);
+        log.info("구글 회원정보 조회 성공");
+        return memberInfo;
     }
 }

--- a/src/main/java/com/debatetimer/filter/logging/LoggingFilter.java
+++ b/src/main/java/com/debatetimer/filter/logging/LoggingFilter.java
@@ -1,0 +1,36 @@
+package com.debatetimer.filter.logging;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Component
+public class LoggingFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        MDC.put("requestId", UUID.randomUUID().toString());
+
+        ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(
+                (HttpServletRequest) servletRequest
+        );
+        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(
+                (HttpServletResponse) servletResponse
+        );
+        filterChain.doFilter(requestWrapper, responseWrapper);
+        responseWrapper.copyBodyToResponse();
+
+        MDC.clear();
+    }
+}

--- a/src/main/java/com/debatetimer/service/auth/AuthService.java
+++ b/src/main/java/com/debatetimer/service/auth/AuthService.java
@@ -9,8 +9,10 @@ import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
 import com.debatetimer.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -31,5 +33,6 @@ public class AuthService {
         if (!member.isSameMember(email)) {
             throw new DTClientErrorException(ClientErrorCode.UNAUTHORIZED_MEMBER);
         }
+        log.info("회원 로그아웃 성공 - 회원 이메일 : {}", email);
     }
 }

--- a/src/main/java/com/debatetimer/service/member/MemberService.java
+++ b/src/main/java/com/debatetimer/service/member/MemberService.java
@@ -9,9 +9,11 @@ import com.debatetimer.repository.member.MemberRepository;
 import com.debatetimer.repository.parliamentary.ParliamentaryTableRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -23,13 +25,17 @@ public class MemberService {
     public TableResponses getTables(Long memberId) {
         Member member = memberRepository.getById(memberId);
         List<ParliamentaryTable> parliamentaryTable = parliamentaryTableRepository.findAllByMember(member);
+        log.info("회원 테이블 정보 조회 성공 - 회원 이메일 : {}", member.getEmail());
         return TableResponses.from(parliamentaryTable);
     }
 
     @Transactional
     public MemberCreateResponse createMember(MemberInfo memberInfo) {
         Member member = memberRepository.findByEmail(memberInfo.email())
-                .orElseGet(() -> memberRepository.save(memberInfo.toMember()));
+                .orElseGet(() -> {
+                    log.info("신규 회원 가입 - 회원 이메일 : {}", memberInfo.email());
+                    return memberRepository.save(memberInfo.toMember());
+                });
         return new MemberCreateResponse(member);
     }
 }

--- a/src/main/java/com/debatetimer/service/parliamentary/ParliamentaryService.java
+++ b/src/main/java/com/debatetimer/service/parliamentary/ParliamentaryService.java
@@ -12,9 +12,11 @@ import com.debatetimer.repository.parliamentary.ParliamentaryTableRepository;
 import com.debatetimer.repository.parliamentary.ParliamentaryTimeBoxRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ParliamentaryService {
@@ -28,6 +30,7 @@ public class ParliamentaryService {
         ParliamentaryTable savedTable = tableRepository.save(table);
 
         ParliamentaryTimeBoxes savedTimeBoxes = saveTimeBoxes(tableCreateRequest, savedTable);
+        log.info("새로운 의회식 토론 시간표 생성 성공");
         return new ParliamentaryTableResponse(savedTable, savedTimeBoxes);
     }
 
@@ -35,6 +38,7 @@ public class ParliamentaryService {
     public ParliamentaryTableResponse findTable(long tableId, Member member) {
         ParliamentaryTable table = getOwnerTable(tableId, member.getId());
         ParliamentaryTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(table);
+        log.info("의회식 토론 시간표 조회 성공");
         return new ParliamentaryTableResponse(table, timeBoxes);
     }
 
@@ -58,6 +62,7 @@ public class ParliamentaryService {
         ParliamentaryTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(existingTable);
         timeBoxRepository.deleteAll(timeBoxes.getTimeBoxes());
         ParliamentaryTimeBoxes savedTimeBoxes = saveTimeBoxes(tableCreateRequest, existingTable);
+        log.info("의회식 토론 시간표 업데이트 성공");
         return new ParliamentaryTableResponse(existingTable, savedTimeBoxes);
     }
 
@@ -67,6 +72,7 @@ public class ParliamentaryService {
         ParliamentaryTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(table);
         timeBoxRepository.deleteAll(timeBoxes.getTimeBoxes());
         tableRepository.delete(table);
+        log.info("의회식 토론 시간표 삭제 성공 - 테이블 아이디 : {}", tableId);
     }
 
     private ParliamentaryTimeBoxes saveTimeBoxes(
@@ -89,6 +95,4 @@ public class ParliamentaryService {
             throw new DTClientErrorException(ClientErrorCode.NOT_TABLE_OWNER);
         }
     }
-
-
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,3 +28,6 @@ jwt:
   secret_key: ${secret.jwt.secret_key}
   access_token_expiration: ${secret.jwt.access_token_expiration}
   refresh_token_expiration: ${secret.jwt.refresh_token_expiration}
+
+logging:
+  config: classpath:logging/log4j2-dev.yml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,3 +28,5 @@ jwt:
   access_token_expiration: ${secret.jwt.access_token_expiration}
   refresh_token_expiration: ${secret.jwt.refresh_token_expiration}
 
+logging:
+  config: classpath:logging/log4j2-prod.yml

--- a/src/main/resources/logging/log4j2-dev.yml
+++ b/src/main/resources/logging/log4j2-dev.yml
@@ -13,7 +13,7 @@ Configuration:
       fileName: ${log-dir}/logfile.log
       filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
       immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
 
       Policies:

--- a/src/main/resources/logging/log4j2-dev.yml
+++ b/src/main/resources/logging/log4j2-dev.yml
@@ -13,7 +13,7 @@ Configuration:
       fileName: ${log-dir}/logfile.log
       filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] [%-5level] %logger{35} - %msg%n"
       immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
 
       Policies:

--- a/src/main/resources/logging/log4j2-dev.yml
+++ b/src/main/resources/logging/log4j2-dev.yml
@@ -1,0 +1,44 @@
+Configuration:
+  name: Dev-Logger
+  status: debug
+
+  Properties:
+    Property:
+      name: log-dir
+      value: "logs"
+
+  Appenders:
+    RollingFile:
+      name: RollingFile_Appender
+      fileName: ${log-dir}/logfile.log
+      filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n"
+      immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
+
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: "10 MB"
+        TimeBasedTriggeringPolicy:
+          Interval: 1
+          modulate: true #다음 롤오버 시간을 정각 바운더리에 맞추는 설정
+      DefaultRollOverStrategy:
+        max: 10
+        Delete:
+          basePath: "${log-dir}"
+          maxDepth: "1"
+          IfLastModified:
+            age: "P7D"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: RollingFile_Appender
+    Logger:
+      name: debate-timer-dev
+      additivity: false
+      level: debug
+      includeLocation: false
+      AppenderRef:
+        ref: RollingFile_Appender

--- a/src/main/resources/logging/log4j2-local.yml
+++ b/src/main/resources/logging/log4j2-local.yml
@@ -15,7 +15,7 @@ Configuration:
       AppenderRef:
         ref: Console_Appender
     Logger:
-      name: debate-timer
+      name: debate-timer-local
       additivity: false
       level: debug
       AppenderRef:

--- a/src/main/resources/logging/log4j2-local.yml
+++ b/src/main/resources/logging/log4j2-local.yml
@@ -7,7 +7,7 @@ Configuration:
       name: Console_Appender
       target: SYSTEM_OUT
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
 
   Loggers:
     Root:

--- a/src/main/resources/logging/log4j2-local.yml
+++ b/src/main/resources/logging/log4j2-local.yml
@@ -7,7 +7,7 @@ Configuration:
       name: Console_Appender
       target: SYSTEM_OUT
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] [%highlight{%-5level}] %logger{35} - %msg%n"
 
   Loggers:
     Root:

--- a/src/main/resources/logging/log4j2-local.yml
+++ b/src/main/resources/logging/log4j2-local.yml
@@ -1,0 +1,22 @@
+Configuration:
+  name: Local-Logger
+  status: debug
+
+  appenders:
+    Console:
+      name: Console_Appender
+      target: SYSTEM_OUT
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{35} - %msg%n"
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: Console_Appender
+    Logger:
+      name: debate-timer
+      additivity: false
+      level: debug
+      AppenderRef:
+        ref: Console_Appender

--- a/src/main/resources/logging/log4j2-prod.yml
+++ b/src/main/resources/logging/log4j2-prod.yml
@@ -13,7 +13,7 @@ Configuration:
       fileName: ${log-dir}/logfile.log
       filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
       immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
 
       Policies:

--- a/src/main/resources/logging/log4j2-prod.yml
+++ b/src/main/resources/logging/log4j2-prod.yml
@@ -13,7 +13,7 @@ Configuration:
       fileName: ${log-dir}/logfile.log
       filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] %-5level %logger{35} - %msg%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} [%X{requestId}] [%thread] [%-5level] %logger{35} - %msg%n"
       immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
 
       Policies:

--- a/src/main/resources/logging/log4j2-prod.yml
+++ b/src/main/resources/logging/log4j2-prod.yml
@@ -1,0 +1,44 @@
+Configuration:
+  name: Dev-Logger
+  status: debug
+
+  Properties:
+    Property:
+      name: log-dir
+      value: "logs"
+
+  Appenders:
+    RollingFile:
+      name: RollingFile_Appender
+      fileName: ${log-dir}/logfile.log
+      filePattern: "${log-dir}logfile-%d{yyyy-MM-dd}.%i.txt"
+      PatternLayout:
+        pattern: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n"
+      immediateFlush: false #false로 설정되어야 Async로 buffer에 저장됨
+
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: "10 MB"
+        TimeBasedTriggeringPolicy:
+          Interval: 1
+          modulate: true #다음 롤오버 시간을 정각 바운더리에 맞추는 설정
+      DefaultRollOverStrategy:
+        max: 30
+        Delete:
+          basePath: "${log-dir}"
+          maxDepth: "1"
+          IfLastModified:
+            age: "P30D" #30일간 데이터는 저장됨
+
+  Loggers:
+    Root:
+      level: info
+      AppenderRef:
+        ref: RollingFile_Appender
+    Logger:
+      name: debate-timer-prod
+      additivity: false
+      level: debug
+      includeLocation: false
+      AppenderRef:
+        ref: RollingFile_Appender


### PR DESCRIPTION
# 🚩 연관 이슈
closed #104 

# 🗣️ 리뷰 요구사항 (선택)

- MDC를 활용해 requestId(UUID)를 함께 로깅하여 요청별 트래킹을 쉽게 하였습니다.
<img width="1289" alt="image" src="https://github.com/user-attachments/assets/5fa6f819-7930-4866-85df-86bfefa1cfc9" />

- 프로파일별 로깅 정책을 분리하였습니다.
    - local : 콘솔 로깅만 도입
    - dev : 7일치 파일 롤링
    - prod : 30일치 파일 롤링

- resources/logging/log4j2-XXX.yml을 통해 yml로 설정파일을 관리하게 하였습니다.


### 다만, 아직 권한 설정 같은 CI/CD 파이프라인 상의 문제는 고려하지 않은 상태에요. 이건 DEV에 머지하는 과정이나 제가 EC2 따로 올려서 테스트 해보겠슴다. 

