### PR TITLE
[FEAT] 멤버의 테이블 조회 시, 테이블 순서 구현

### DIFF
--- a/src/main/java/com/debatetimer/config/JpaAuditingConfig.java
+++ b/src/main/java/com/debatetimer/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.debatetimer.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/debatetimer/domain/BaseTimeEntity.java
+++ b/src/main/java/com/debatetimer/domain/BaseTimeEntity.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
-@MappedSuperclass
 @Getter
+@MappedSuperclass
 public abstract class BaseTimeEntity {
 
     @CreatedDate

--- a/src/main/java/com/debatetimer/domain/BaseTimeEntity.java
+++ b/src/main/java/com/debatetimer/domain/BaseTimeEntity.java
@@ -1,0 +1,18 @@
+package com.debatetimer.domain;
+
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/debatetimer/domain/DebateTable.java
+++ b/src/main/java/com/debatetimer/domain/DebateTable.java
@@ -53,6 +53,7 @@ public abstract class DebateTable extends BaseTimeEntity {
         this.duration = duration;
         this.warningBell = warningBell;
         this.finishBell = finishBell;
+        this.usedAt = LocalDateTime.now();
     }
 
     public final boolean isOwner(long memberId) {
@@ -67,6 +68,7 @@ public abstract class DebateTable extends BaseTimeEntity {
         this.duration = renewTable.getDuration();
         this.warningBell = renewTable.isWarningBell();
         this.finishBell = renewTable.isFinishBell();
+        this.usedAt = LocalDateTime.now();
     }
 
     private void validate(String name, int duration) {

--- a/src/main/java/com/debatetimer/domain/DebateTable.java
+++ b/src/main/java/com/debatetimer/domain/DebateTable.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @MappedSuperclass
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class DebateTable {
+public abstract class DebateTable extends BaseTimeEntity {
 
     private static final String NAME_REGEX = "^[a-zA-Z가-힣0-9 ]+$";
     public static final int NAME_MAX_LENGTH = 20;
@@ -38,6 +39,9 @@ public abstract class DebateTable {
     private boolean warningBell;
 
     private boolean finishBell;
+
+    @NotNull
+    private LocalDateTime usedAt;
 
     protected DebateTable(Member member, String name, String agenda, int duration, boolean warningBell,
                           boolean finishBell) {
@@ -77,7 +81,7 @@ public abstract class DebateTable {
         }
     }
 
-    abstract public long getId();
+    public abstract long getId();
 
-    abstract public TableType getType();
+    public abstract TableType getType();
 }

--- a/src/main/java/com/debatetimer/domain/DebateTable.java
+++ b/src/main/java/com/debatetimer/domain/DebateTable.java
@@ -60,6 +60,10 @@ public abstract class DebateTable extends BaseTimeEntity {
         return Objects.equals(this.member.getId(), memberId);
     }
 
+    public final void updateUsedAt() {
+        this.usedAt = LocalDateTime.now();
+    }
+
     protected final void updateTable(DebateTable renewTable) {
         validate(renewTable.getName(), renewTable.getDuration());
 
@@ -68,7 +72,7 @@ public abstract class DebateTable extends BaseTimeEntity {
         this.duration = renewTable.getDuration();
         this.warningBell = renewTable.isWarningBell();
         this.finishBell = renewTable.isFinishBell();
-        this.usedAt = LocalDateTime.now();
+        updateUsedAt();
     }
 
     private void validate(String name, int duration) {

--- a/src/main/java/com/debatetimer/domain/member/Member.java
+++ b/src/main/java/com/debatetimer/domain/member/Member.java
@@ -1,5 +1,6 @@
 package com.debatetimer.domain.member;
 
+import com.debatetimer.domain.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/debatetimer/dto/member/TableResponses.java
+++ b/src/main/java/com/debatetimer/dto/member/TableResponses.java
@@ -1,11 +1,17 @@
 package com.debatetimer.dto.member;
 
+import com.debatetimer.domain.DebateTable;
 import com.debatetimer.domain.parliamentary.ParliamentaryTable;
 import com.debatetimer.domain.timebased.TimeBasedTable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
 public record TableResponses(List<TableResponse> tables) {
+
+    private static final Comparator<DebateTable> DEBATE_TABLE_COMPARATOR = Comparator
+            .comparing(DebateTable::getUsedAt)
+            .reversed();
 
     public TableResponses(List<ParliamentaryTable> parliamentaryTables,
                           List<TimeBasedTable> timeBasedTables) {
@@ -14,11 +20,9 @@ public record TableResponses(List<TableResponse> tables) {
 
     private static List<TableResponse> toTableResponses(List<ParliamentaryTable> parliamentaryTables,
                                                         List<TimeBasedTable> timeBasedTables) {
-        Stream<TableResponse> parliamentaryTableResponseStream = parliamentaryTables.stream()
-                .map(TableResponse::new);
-        Stream<TableResponse> timeBasedTableResponseStream = timeBasedTables.stream()
-                .map(TableResponse::new);
-        return Stream.concat(parliamentaryTableResponseStream, timeBasedTableResponseStream)
+        return Stream.concat(parliamentaryTables.stream(), timeBasedTables.stream())
+                .sorted(DEBATE_TABLE_COMPARATOR)
+                .map(TableResponse::new)
                 .toList();
     }
 }

--- a/src/main/resources/db/migration/V3__add_auditing_column.sql
+++ b/src/main/resources/db/migration/V3__add_auditing_column.sql
@@ -1,0 +1,10 @@
+alter table member add column created_at timestamp default current_timestamp not null;
+alter table member add column modified_at timestamp default current_timestamp not null;
+
+alter table parliamentary_table add column created_at timestamp default current_timestamp not null;
+alter table parliamentary_table add column modified_at timestamp default current_timestamp not null;
+alter table parliamentary_table add column used_at timestamp default current_timestamp not null;
+
+alter table time_based_table add column created_at timestamp default current_timestamp not null;
+alter table time_based_table add column modified_at timestamp default current_timestamp not null;
+alter table time_based_table add column used_at timestamp default current_timestamp not null;

--- a/src/test/java/com/debatetimer/DatabaseSchemaManagerTest.java
+++ b/src/test/java/com/debatetimer/DatabaseSchemaManagerTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("flyway")
-public class DatabaseSchemaManagerTest {
+class DatabaseSchemaManagerTest {
 
     @Autowired
     private Flyway flyway;

--- a/src/test/java/com/debatetimer/domain/DebateTableTest.java
+++ b/src/test/java/com/debatetimer/domain/DebateTableTest.java
@@ -9,6 +9,7 @@ import com.debatetimer.domain.member.Member;
 import com.debatetimer.dto.member.TableType;
 import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -83,6 +84,20 @@ class DebateTableTest {
                     () -> assertThat(table.isWarningBell()).isEqualTo(false),
                     () -> assertThat(table.isFinishBell()).isEqualTo(false)
             );
+        }
+
+        @Test
+        void 테이블_업데이트_할_때_사용_시간을_변경한다() throws InterruptedException {
+            Member member = new Member("default@gmail.com");
+            DebateTableTestObject table = new DebateTableTestObject(member, "tableName", "agenda", 10, true, true);
+            DebateTableTestObject renewTable = new DebateTableTestObject(member, "newName", "newAgenda", 100, false,
+                    false);
+            LocalDateTime beforeUsedAt = table.getUsedAt();
+            Thread.sleep(1);
+
+            table.updateTable(renewTable);
+
+            assertThat(table.getUsedAt()).isAfter(beforeUsedAt);
         }
     }
 

--- a/src/test/java/com/debatetimer/domain/DebateTableTest.java
+++ b/src/test/java/com/debatetimer/domain/DebateTableTest.java
@@ -66,6 +66,22 @@ class DebateTableTest {
     }
 
     @Nested
+    class UpdateUsedAt {
+
+        @Test
+        void 테이블의_사용_시각을_업데이트한다() throws InterruptedException {
+            Member member = new Member("default@gmail.com");
+            DebateTableTestObject table = new DebateTableTestObject(member, "tableName", "agenda", 10, true, true);
+            LocalDateTime beforeUsedAt = table.getUsedAt();
+            Thread.sleep(1);
+
+            table.updateUsedAt();
+
+            assertThat(table.getUsedAt()).isAfter(beforeUsedAt);
+        }
+    }
+
+    @Nested
     class Update {
 
         @Test


### PR DESCRIPTION
# 🚩 연관 이슈
closed #108 

# 🗣️ 추가 설명
크게는 두가지 안을 생각했다. (이 중에 2안을 선택)
1. created_at, modified_at, used_at 을 최대한 Clock 객체를 통해 수동으로 관리 + Mocking Clock 을 이용해 테스트 용이성 가져가기
    -> 우리가 시간에 그렇게 민감한 도메인이 아니기 때문에 다단계 상속으로 이루어진 모든 객체들이 Clock이나 현재 시간 값을 인자로 받아가면서 관리하는 것은 조금 별로라고 생각했다.
2. JpaAuditing 을 사용하면서 도메인에서 LocalDateTime.now()를 사용하며 관리
    -> 테스트 할 때 Thread.sleep() 을 이용하여 가독성이 떨어진다는 불편함이 있지만, 시간에 대해 민감한 곳이 한 곳 밖에 없어 이것을 사용하는 것이 적절하다고 판단했다.