### PR TITLE
[FEAT] 자유 토론 타임 박스 nullable 수정

### DIFF
--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
@@ -101,6 +101,10 @@ public class CustomizeTimeBox extends DebateTimeBox {
 
     private void validateTimeBasedTimes(Integer timePerTeam, Integer timePerSpeaking) {
         validateTime(timePerTeam);
+        if (timePerSpeaking == null) {
+            return;
+        }
+
         validateTime(timePerSpeaking);
         if (timePerTeam < timePerSpeaking) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME);

--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 public class CustomizeTimeBox extends DebateTimeBox {
 
     public static final int SPEECH_TYPE_MAX_LENGTH = 10;
+    public static final int TIME_MULTIPLIER = 2;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -69,14 +70,12 @@ public class CustomizeTimeBox extends DebateTimeBox {
             Stance stance,
             String speechType,
             CustomizeBoxType boxType,
-            int time,
             int timePerTeam,
             Integer timePerSpeaking,
             String speaker
     ) {
-        super(sequence, stance, time, speaker);
+        super(sequence, stance, timePerTeam * TIME_MULTIPLIER, speaker);
         validateTime(timePerTeam, timePerSpeaking);
-        validateTimeBasedTime(time, timePerTeam);
         validateTimeBasedType(boxType);
         validateSpeechType(speechType);
 
@@ -98,12 +97,6 @@ public class CustomizeTimeBox extends DebateTimeBox {
         validateTime(timePerSpeaking);
         if (timePerTeam < timePerSpeaking) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME);
-        }
-    }
-
-    private void validateTimeBasedTime(int time, int timePerTeam) {
-        if (time != timePerTeam * 2) {
-            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME_IS_NOT_DOUBLE);
         }
     }
 

--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBox.java
@@ -52,7 +52,7 @@ public class CustomizeTimeBox extends DebateTimeBox {
             Stance stance,
             String speechType,
             CustomizeBoxType boxType,
-            int time,
+            Integer time,
             String speaker
     ) {
         super(sequence, stance, time, speaker);
@@ -70,12 +70,12 @@ public class CustomizeTimeBox extends DebateTimeBox {
             Stance stance,
             String speechType,
             CustomizeBoxType boxType,
-            int timePerTeam,
+            Integer timePerTeam,
             Integer timePerSpeaking,
             String speaker
     ) {
-        super(sequence, stance, timePerTeam * TIME_MULTIPLIER, speaker);
-        validateTime(timePerTeam, timePerSpeaking);
+        super(sequence, stance, convertToTime(timePerTeam), speaker);
+        validateTimeBasedTimes(timePerTeam, timePerSpeaking);
         validateTimeBasedType(boxType);
         validateSpeechType(speechType);
 
@@ -86,13 +86,20 @@ public class CustomizeTimeBox extends DebateTimeBox {
         this.timePerSpeaking = timePerSpeaking;
     }
 
-    private void validateTime(int time) {
-        if (time <= 0) {
+    private static int convertToTime(Integer timePerTeam) {
+        if (timePerTeam == null) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_FORMAT);
+        }
+        return timePerTeam * TIME_MULTIPLIER;
+    }
+
+    private void validateTime(Integer time) {
+        if (time == null || time <= 0) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
         }
     }
 
-    private void validateTime(int timePerTeam, int timePerSpeaking) {
+    private void validateTimeBasedTimes(Integer timePerTeam, Integer timePerSpeaking) {
         validateTime(timePerTeam);
         validateTime(timePerSpeaking);
         if (timePerTeam < timePerSpeaking) {

--- a/src/main/java/com/debatetimer/domain/timebased/TimeBasedTimeBox.java
+++ b/src/main/java/com/debatetimer/domain/timebased/TimeBasedTimeBox.java
@@ -23,6 +23,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeBasedTimeBox extends DebateTimeBox {
 
+    public static final int TIME_MULTIPLIER = 2;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -60,14 +62,12 @@ public class TimeBasedTimeBox extends DebateTimeBox {
             int sequence,
             Stance stance,
             TimeBasedBoxType type,
-            int time,
             int timePerTeam,
             int timePerSpeaking,
             Integer speaker
     ) {
-        super(sequence, stance, time, String.valueOf(speaker));
+        super(sequence, stance, timePerTeam * TIME_MULTIPLIER, String.valueOf(speaker));
         validateTime(timePerTeam, timePerSpeaking);
-        validateTimeBasedTime(time, timePerTeam);
         validateStance(stance, type);
         validateTimeBasedType(type);
         validateSpeakerNumber(speaker);
@@ -89,12 +89,6 @@ public class TimeBasedTimeBox extends DebateTimeBox {
         validateTime(timePerSpeaking);
         if (timePerTeam < timePerSpeaking) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME);
-        }
-    }
-
-    private void validateTimeBasedTime(int time, int timePerTeam) {
-        if (time != timePerTeam * 2) {
-            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME_IS_NOT_DOUBLE);
         }
     }
 

--- a/src/main/java/com/debatetimer/dto/customize/request/CustomizeTimeBoxCreateRequest.java
+++ b/src/main/java/com/debatetimer/dto/customize/request/CustomizeTimeBoxCreateRequest.java
@@ -6,6 +6,7 @@ import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.customize.CustomizeTimeBox;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.lang.Nullable;
 
 public record CustomizeTimeBoxCreateRequest(
         @NotNull
@@ -17,9 +18,16 @@ public record CustomizeTimeBoxCreateRequest(
         @NotNull
         CustomizeBoxType boxType,
 
-        int time,
+        @Nullable
+        Integer time,
+
+        @Nullable
         Integer timePerTeam,
+
+        @Nullable
         Integer timePerSpeaking,
+
+        @Nullable
         String speaker
 ) {
 

--- a/src/main/java/com/debatetimer/dto/customize/request/CustomizeTimeBoxCreateRequest.java
+++ b/src/main/java/com/debatetimer/dto/customize/request/CustomizeTimeBoxCreateRequest.java
@@ -25,7 +25,7 @@ public record CustomizeTimeBoxCreateRequest(
 
     public CustomizeTimeBox toTimeBox(CustomizeTable customizeTable, int sequence) {
         if (boxType.isTimeBased()) {
-            return new CustomizeTimeBox(customizeTable, sequence, stance, speechType, boxType, time, timePerTeam,
+            return new CustomizeTimeBox(customizeTable, sequence, stance, speechType, boxType, timePerTeam,
                     timePerSpeaking, speaker);
         }
         return new CustomizeTimeBox(customizeTable, sequence, stance, speechType, boxType, time, speaker);

--- a/src/main/java/com/debatetimer/dto/timebased/request/TimeBasedTimeBoxCreateRequest.java
+++ b/src/main/java/com/debatetimer/dto/timebased/request/TimeBasedTimeBoxCreateRequest.java
@@ -21,7 +21,7 @@ public record TimeBasedTimeBoxCreateRequest(
 
     public TimeBasedTimeBox toTimeBox(TimeBasedTable timeBasedTable, int sequence) {
         if (type.isTimeBased()) {
-            return new TimeBasedTimeBox(timeBasedTable, sequence, stance, type, time, timePerTeam, timePerSpeaking,
+            return new TimeBasedTimeBox(timeBasedTable, sequence, stance, type, timePerTeam, timePerSpeaking,
                     speakerNumber);
         }
         return new TimeBasedTimeBox(timeBasedTable, sequence, stance, type, time, speakerNumber);

--- a/src/main/java/com/debatetimer/exception/errorcode/ClientErrorCode.java
+++ b/src/main/java/com/debatetimer/exception/errorcode/ClientErrorCode.java
@@ -26,7 +26,6 @@ public enum ClientErrorCode implements ResponseErrorCode {
     INVALID_TIME_BOX_STANCE(HttpStatus.BAD_REQUEST, "타임박스 유형과 일치하지 않는 입장입니다."),
     INVALID_TIME_BOX_FORMAT(HttpStatus.BAD_REQUEST, "타임박스 유형과 일치하지 않는 형식입니다"),
     INVALID_TIME_BASED_TIME(HttpStatus.BAD_REQUEST, "팀 발언 시간은 개인 발언 시간보다 길어야합니다"),
-    INVALID_TIME_BASED_TIME_IS_NOT_DOUBLE(HttpStatus.BAD_REQUEST, "총 시간은 팀 발언 시간의 2배여야 합니다"),
     INVALID_TIME_BOX_SPEECH_TYPE_LENGTH(
             HttpStatus.BAD_REQUEST,
             "발언 유형 이름은 1자 이상 %d자 이하여야 합니다.".formatted(CustomizeTimeBox.SPEECH_TYPE_MAX_LENGTH)

--- a/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxTest.java
@@ -1,5 +1,6 @@
 package com.debatetimer.domain.customize;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -15,25 +16,12 @@ class CustomizeTimeBoxTest {
     class ValidateCustomizeTime {
 
         @Test
-        void 자유토론_타입은_총_시간이_팀_발언_시간의_2배여야_한다() {
-            CustomizeTable table = new CustomizeTable();
-            CustomizeBoxType customizeBoxType = CustomizeBoxType.TIME_BASED;
-
-            int totalTime = 150;
-            int timePerTeam = 120;
-
-            assertThatThrownBy(() -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", customizeBoxType, totalTime,
-                    timePerTeam, 60, "발언자")).isInstanceOf(DTClientErrorException.class)
-                    .hasMessage(ClientErrorCode.INVALID_TIME_BASED_TIME_IS_NOT_DOUBLE.getMessage());
-        }
-
-        @Test
         void 자유토론_타입은_개인_발언_시간과_팀_발언_시간을_입력해야_한다() {
             CustomizeTable table = new CustomizeTable();
             CustomizeBoxType customizeBoxType = CustomizeBoxType.TIME_BASED;
 
             assertThatCode(() -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론",
-                    customizeBoxType, 240, 120, 60, "발언자")
+                    customizeBoxType, 120, 60, "발언자")
             ).doesNotThrowAnyException();
         }
 
@@ -53,7 +41,7 @@ class CustomizeTimeBoxTest {
             CustomizeBoxType notTimeBasedBoxType = CustomizeBoxType.NORMAL;
 
             assertThatThrownBy(
-                    () -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", notTimeBasedBoxType, 240, 120, 60,
+                    () -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", notTimeBasedBoxType, 120, 60,
                             "발언자")).isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_FORMAT.getMessage());
         }
@@ -65,7 +53,7 @@ class CustomizeTimeBoxTest {
             int timePerSpeaking = 59;
 
             assertThatCode(() -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", CustomizeBoxType.TIME_BASED,
-                    timePerTeam * 2, timePerTeam, timePerSpeaking, "발언자")).doesNotThrowAnyException();
+                    timePerTeam, timePerSpeaking, "발언자")).doesNotThrowAnyException();
         }
 
         @Test
@@ -75,7 +63,7 @@ class CustomizeTimeBoxTest {
             int timePerSpeaking = 61;
 
             assertThatThrownBy(() -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", CustomizeBoxType.TIME_BASED,
-                    timePerTeam * 2, timePerTeam, timePerSpeaking, "발언자")).isInstanceOf(DTClientErrorException.class)
+                    timePerTeam, timePerSpeaking, "발언자")).isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BASED_TIME.getMessage());
         }
 
@@ -86,8 +74,23 @@ class CustomizeTimeBoxTest {
 
             assertThatThrownBy(
                     () -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, longSpeechType, CustomizeBoxType.TIME_BASED,
-                            240, 120, 60, "발언자")).isInstanceOf(DTClientErrorException.class)
+                            120, 60, "발언자")).isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SPEECH_TYPE_LENGTH.getMessage());
+        }
+    }
+
+    @Nested
+    class getTime {
+
+        @Test
+        void 자유_토론_타임_박스의_시간은_팀_당_발언_시간의_배수이어야_한다() {
+            int timePerTeam = 300;
+            int timePerSpeaking = 120;
+            CustomizeTable table = new CustomizeTable();
+            CustomizeTimeBox timeBasedTimeBox = new CustomizeTimeBox(table, 1, Stance.CONS, "자유 토론",
+                    CustomizeBoxType.TIME_BASED, timePerTeam, timePerSpeaking, "콜리");
+
+            assertThat(timeBasedTimeBox.getTime()).isEqualTo(timePerTeam * CustomizeTimeBox.TIME_MULTIPLIER);
         }
     }
 }

--- a/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxTest.java
@@ -47,6 +47,16 @@ class CustomizeTimeBoxTest {
         }
 
         @Test
+        void 팀_발언_시간은_있으며_개인_발언_시간은_없을_수_있다() {
+            CustomizeTable table = new CustomizeTable();
+            Integer timePerTeam = 60;
+            Integer timePerSpeaking = null;
+
+            assertThatCode(() -> new CustomizeTimeBox(table, 1, Stance.NEUTRAL, "자유토론", CustomizeBoxType.TIME_BASED,
+                    timePerTeam, timePerSpeaking, "발언자")).doesNotThrowAnyException();
+        }
+
+        @Test
         void 개인_발언_시간은_팀_발언_시간보다_적거나_같아야_한다() {
             CustomizeTable table = new CustomizeTable();
             int timePerTeam = 60;

--- a/src/test/java/com/debatetimer/domain/timebased/TimeBasedTimeBoxTest.java
+++ b/src/test/java/com/debatetimer/domain/timebased/TimeBasedTimeBoxTest.java
@@ -118,7 +118,7 @@ class TimeBasedTimeBoxTest {
             int timePerTeam = 300;
             int timePerSpeaking = 120;
             TimeBasedTable table = new TimeBasedTable();
-            TimeBasedTimeBox timeBasedTimeBox = new TimeBasedTimeBox(table, 1, Stance.CONS, TimeBasedBoxType.OPENING,
+            TimeBasedTimeBox timeBasedTimeBox = new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED,
                     timePerTeam, timePerSpeaking, 1);
 
             assertThat(timeBasedTimeBox.getTime()).isEqualTo(timePerTeam * TimeBasedTimeBox.TIME_MULTIPLIER);

--- a/src/test/java/com/debatetimer/domain/timebased/TimeBasedTimeBoxTest.java
+++ b/src/test/java/com/debatetimer/domain/timebased/TimeBasedTimeBoxTest.java
@@ -1,5 +1,6 @@
 package com.debatetimer.domain.timebased;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -39,22 +40,11 @@ class TimeBasedTimeBoxTest {
     class ValidateTimeBased {
 
         @Test
-        void 시간총량제_타입은_총_시간이_팀_발언_시간의_2배여야_한다() {
-            TimeBasedTable table = new TimeBasedTable();
-            TimeBasedBoxType timeBasedBoxType = TimeBasedBoxType.TIME_BASED;
-
-            assertThatThrownBy(
-                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, timeBasedBoxType, 150, 120, 60, 1))
-                    .isInstanceOf(DTClientErrorException.class)
-                    .hasMessage(ClientErrorCode.INVALID_TIME_BASED_TIME_IS_NOT_DOUBLE.getMessage());
-        }
-
-        @Test
         void 시간총량제_타입은_개인_발언_시간과_팀_발언_시간을_입력해야_한다() {
             TimeBasedTable table = new TimeBasedTable();
             TimeBasedBoxType timeBasedBoxType = TimeBasedBoxType.TIME_BASED;
 
-            assertThatCode(() -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, timeBasedBoxType, 240, 120, 60, 1))
+            assertThatCode(() -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, timeBasedBoxType, 120, 60, 1))
                     .doesNotThrowAnyException();
         }
 
@@ -74,7 +64,7 @@ class TimeBasedTimeBoxTest {
             TimeBasedBoxType notTimeBasedBoxType = TimeBasedBoxType.TIME_OUT;
 
             assertThatThrownBy(
-                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, notTimeBasedBoxType, 240, 120, 60, 1))
+                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, notTimeBasedBoxType, 120, 60, 1))
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_FORMAT.getMessage());
         }
@@ -86,7 +76,7 @@ class TimeBasedTimeBoxTest {
             int timePerSpeaking = 59;
 
             assertThatCode(
-                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED, timePerTeam * 2,
+                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED,
                             timePerTeam, timePerSpeaking, 1))
                     .doesNotThrowAnyException();
         }
@@ -98,7 +88,7 @@ class TimeBasedTimeBoxTest {
             int timePerSpeaking = 61;
 
             assertThatThrownBy(
-                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED, timePerTeam * 2,
+                    () -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED,
                             timePerTeam, timePerSpeaking, 1))
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BASED_TIME.getMessage());
@@ -114,9 +104,24 @@ class TimeBasedTimeBoxTest {
             TimeBasedTable table = new TimeBasedTable();
 
             assertThatThrownBy(() -> new TimeBasedTimeBox(table, 1, Stance.NEUTRAL, TimeBasedBoxType.TIME_BASED,
-                    240, 120, 60, speaker))
+                    120, 60, speaker))
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SPEAKER.getMessage());
+        }
+    }
+
+    @Nested
+    class getTime {
+
+        @Test
+        void 자유_토론_타임_박스의_시간은_팀_당_발언_시간의_배수이어야_한다() {
+            int timePerTeam = 300;
+            int timePerSpeaking = 120;
+            TimeBasedTable table = new TimeBasedTable();
+            TimeBasedTimeBox timeBasedTimeBox = new TimeBasedTimeBox(table, 1, Stance.CONS, TimeBasedBoxType.OPENING,
+                    timePerTeam, timePerSpeaking, 1);
+
+            assertThat(timeBasedTimeBox.getTime()).isEqualTo(timePerTeam * TimeBasedTimeBox.TIME_MULTIPLIER);
         }
     }
 }


### PR DESCRIPTION
# 🚩 연관 이슈
closed #144 

# 🗣️ 리뷰 요구사항 (선택)
- 리뷰 보기 힘드시면 커밋 단위로 보세요
- 작업 사항은 아래와 같습니다.
  - 1 - 자유 토론 타임 박스에서 time을 timePerteam의 2배 유효성 검사 제거
  - 2.1 - timePerSpeaking을 nullable하게 변경
  - 2.2 - 자유 토론 타임 박스에서 time을 nullable하게 변경
  - 3 - timePerTeam의 값이 있어도, timePerSpeaking의 값이 null이 가능하도록 변경