### PR TITLE
[FIX] '토론 테이블 변경 API' 동시성 문제

### DIFF
--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -13,6 +13,7 @@ import com.debatetimer.repository.customize.CustomizeTimeBoxRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -38,7 +39,7 @@ public class CustomizeService {
         return new CustomizeTableResponse(table, timeBoxes);
     }
 
-    @Transactional
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     public CustomizeTableResponse updateTable(
             CustomizeTableCreateRequest tableCreateRequest,
             long tableId,

--- a/src/main/java/com/debatetimer/service/parliamentary/ParliamentaryService.java
+++ b/src/main/java/com/debatetimer/service/parliamentary/ParliamentaryService.java
@@ -13,6 +13,7 @@ import com.debatetimer.repository.parliamentary.ParliamentaryTimeBoxRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -45,7 +46,7 @@ public class ParliamentaryService {
         return new ParliamentaryTableResponse(table, timeBoxes);
     }
 
-    @Transactional
+    @Transactional(isolation = Isolation.SERIALIZABLE)
     public ParliamentaryTableResponse updateTable(
             ParliamentaryTableCreateRequest tableCreateRequest,
             long tableId,

--- a/src/test/java/com/debatetimer/service/BaseServiceTest.java
+++ b/src/test/java/com/debatetimer/service/BaseServiceTest.java
@@ -11,6 +11,8 @@ import com.debatetimer.repository.customize.CustomizeTimeBoxRepository;
 import com.debatetimer.repository.member.MemberRepository;
 import com.debatetimer.repository.parliamentary.ParliamentaryTableRepository;
 import com.debatetimer.repository.parliamentary.ParliamentaryTimeBoxRepository;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,4 +50,15 @@ public abstract class BaseServiceTest {
 
     @Autowired
     protected CustomizeTimeBoxGenerator customizeTimeBoxGenerator;
+
+    protected void runAtSameTime(int count, Runnable task) throws InterruptedException {
+        List<Thread> threads = IntStream.range(0, count)
+                .mapToObj(i -> new Thread(task))
+                .toList();
+
+        threads.forEach(Thread::start);
+        for (Thread thread : threads) {
+            thread.join();
+        }
+    }
 }

--- a/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
+++ b/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
@@ -140,6 +140,26 @@ class CustomizeServiceTest extends BaseServiceTest {
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.NOT_TABLE_OWNER.getMessage());
         }
+
+        @Test
+        void 테이블_정보_수정을_동시에_요청할_때_동시에_처리하지_않는다() throws InterruptedException {
+            Member member = memberGenerator.generate("default@gmail.com");
+            CustomizeTable table = customizeTableGenerator.generate(member);
+            CustomizeTableCreateRequest request = new CustomizeTableCreateRequest(
+                    new CustomizeTableInfoCreateRequest("자유 테이블", "주제", "찬성",
+                            "반대", true, true),
+                    List.of(
+                            new CustomizeTimeBoxCreateRequest(Stance.PROS, "입론1", CustomizeBoxType.NORMAL,
+                                    120, 60, null, "발언자1"),
+                            new CustomizeTimeBoxCreateRequest(Stance.PROS, "입론2", CustomizeBoxType.NORMAL,
+                                    120, 60, null, "발언자2")
+                    )
+            );
+
+            runAtSameTime(2, () -> customizeService.updateTable(request, table.getId(), member));
+
+            assertThat(customizeTimeBoxRepository.findAllByCustomizeTable(table)).hasSize(2);
+        }
     }
 
     @Nested

--- a/src/test/java/com/debatetimer/service/parliamentary/ParliamentaryServiceTest.java
+++ b/src/test/java/com/debatetimer/service/parliamentary/ParliamentaryServiceTest.java
@@ -122,6 +122,20 @@ class ParliamentaryServiceTest extends BaseServiceTest {
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.NOT_TABLE_OWNER.getMessage());
         }
+
+        @Test
+        void 테이블_정보_수정을_동시에_요청할_때_동시에_처리하지_않는다() throws InterruptedException {
+            Member member = memberGenerator.generate("default@gmail.com");
+            ParliamentaryTable table = parliamentaryTableGenerator.generate(member);
+            ParliamentaryTableCreateRequest request = new ParliamentaryTableCreateRequest(
+                    new ParliamentaryTableInfoCreateRequest("커찬의 테이블", "주제", true, true),
+                    List.of(new ParliamentaryTimeBoxCreateRequest(Stance.PROS, ParliamentaryBoxType.OPENING, 3, 1),
+                            new ParliamentaryTimeBoxCreateRequest(Stance.CONS, ParliamentaryBoxType.OPENING, 3, 1)));
+
+            runAtSameTime(2, () -> parliamentaryService.updateTable(request, member.getId(), member));
+
+            assertThat(parliamentaryTimeBoxRepository.findAllByParliamentaryTable(table)).hasSize(2);
+        }
     }
 
     @Nested


### PR DESCRIPTION
# 🚩 연관 이슈
#167 

# 🗣️ 리뷰 요구사항 (선택)
- 격리 수준을 `SERIALIZABLE`로 일단 올렸습니다. 뒷 요청이 데드락 걸려서 500 에러 내버지만, 일단 속도가 중요한 것 같아서 빠르게 반영하고자 합니다.
- 일단 한 요청을 에러내버리기 때문에 데이터가 중복으로 들어가는 일은 없습니다!
- 머지할꺼면 오늘 Prod 까지 반영하고, 아니면 내일 더 고민해보고 올리겠습니다!
![image](https://github.com/user-attachments/assets/1f7c3d8f-77ad-4304-bed8-0d9ff0c6a4ae)
