### PR TITLE
[REFACTOR] 타임 박스 삭제&저장 동시성 이슈 리팩토링

### DIFF
--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
@@ -2,11 +2,8 @@ package com.debatetimer.repository.customize;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.member.Member;
-import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface CustomizeTableRepository extends Repository<CustomizeTable, Long> {
@@ -18,10 +15,6 @@ public interface CustomizeTableRepository extends Repository<CustomizeTable, Lon
     List<CustomizeTable> findAllByMember(Member member);
 
     Optional<CustomizeTable> findByIdAndMember(long tableId, Member member);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT c FROM CustomizeTable c WHERE c.id = :id AND c.member = :member")
-    Optional<CustomizeTable> findByIdAndMemberWithLock(long id, Member member);
 
     void delete(CustomizeTable table);
 }

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
@@ -2,6 +2,8 @@ package com.debatetimer.repository.customize;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
@@ -15,6 +17,11 @@ public interface CustomizeTableRepository extends Repository<CustomizeTable, Lon
     List<CustomizeTable> findAllByMember(Member member);
 
     Optional<CustomizeTable> findByIdAndMember(long tableId, Member member);
+
+    default CustomizeTable getByIdAndMember(long tableId, Member member) {
+        return findByIdAndMember(tableId, member)
+                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+    }
 
     void delete(CustomizeTable table);
 }

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
@@ -31,4 +31,8 @@ public interface CustomizeTimeBoxRepository extends Repository<CustomizeTimeBox,
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
     void deleteAll(List<CustomizeTimeBox> timeBoxes);
+
+    @Query("DELETE FROM CustomizeTimeBox ctb WHERE ctb.customizeTable = :table")
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteAllByTable(CustomizeTable table);
 }

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
@@ -27,11 +27,6 @@ public interface CustomizeTimeBoxRepository extends Repository<CustomizeTimeBox,
         return new CustomizeTimeBoxes(timeBoxes);
     }
 
-    @Query("DELETE FROM CustomizeTimeBox ctb WHERE ctb IN :timeBoxes")
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Transactional
-    void deleteAll(List<CustomizeTimeBox> timeBoxes);
-
     @Query("DELETE FROM CustomizeTimeBox ctb WHERE ctb.customizeTable = :table")
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     void deleteAllByTable(CustomizeTable table);

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -45,13 +45,12 @@ public class CustomizeService {
             long tableId,
             Member member
     ) {
-        CustomizeTable existingTable = tableRepository.findByIdAndMemberWithLock(tableId, member)
+        CustomizeTable existingTable = tableRepository.findByIdAndMember(tableId, member)
                 .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
         CustomizeTable renewedTable = tableCreateRequest.toTable(member);
         existingTable.updateTable(renewedTable);
 
-        CustomizeTimeBoxes customizeTimeBoxes = timeBoxRepository.findTableTimeBoxes(existingTable);
-        timeBoxRepository.deleteAll(customizeTimeBoxes.getTimeBoxes());
+        timeBoxRepository.deleteAllByTable(existingTable);
         CustomizeTimeBoxes savedCustomizeTimeBoxes = saveTimeBoxes(tableCreateRequest, existingTable);
         return new CustomizeTableResponse(existingTable, savedCustomizeTimeBoxes);
     }
@@ -70,8 +69,7 @@ public class CustomizeService {
     public void deleteTable(long tableId, Member member) {
         CustomizeTable table = tableRepository.findByIdAndMember(tableId, member)
                 .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
-        CustomizeTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(table);
-        timeBoxRepository.deleteAll(timeBoxes.getTimeBoxes());
+        timeBoxRepository.deleteAllByTable(table);
         tableRepository.delete(table);
     }
 

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -6,8 +6,6 @@ import com.debatetimer.domain.customize.CustomizeTimeBoxes;
 import com.debatetimer.domain.member.Member;
 import com.debatetimer.dto.customize.request.CustomizeTableCreateRequest;
 import com.debatetimer.dto.customize.response.CustomizeTableResponse;
-import com.debatetimer.exception.custom.DTClientErrorException;
-import com.debatetimer.exception.errorcode.ClientErrorCode;
 import com.debatetimer.repository.customize.CustomizeTableRepository;
 import com.debatetimer.repository.customize.CustomizeTimeBoxRepository;
 import java.util.List;
@@ -33,8 +31,7 @@ public class CustomizeService {
 
     @Transactional(readOnly = true)
     public CustomizeTableResponse findTable(long tableId, Member member) {
-        CustomizeTable table = tableRepository.findByIdAndMember(tableId, member)
-                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+        CustomizeTable table = tableRepository.getByIdAndMember(tableId, member);
         CustomizeTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(table);
         return new CustomizeTableResponse(table, timeBoxes);
     }
@@ -45,8 +42,7 @@ public class CustomizeService {
             long tableId,
             Member member
     ) {
-        CustomizeTable existingTable = tableRepository.findByIdAndMember(tableId, member)
-                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+        CustomizeTable existingTable = tableRepository.getByIdAndMember(tableId, member);
         CustomizeTable renewedTable = tableCreateRequest.toTable(member);
         existingTable.updateTable(renewedTable);
 
@@ -57,8 +53,7 @@ public class CustomizeService {
 
     @Transactional
     public CustomizeTableResponse updateUsedAt(long tableId, Member member) {
-        CustomizeTable table = tableRepository.findByIdAndMember(tableId, member)
-                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+        CustomizeTable table = tableRepository.getByIdAndMember(tableId, member);
         CustomizeTimeBoxes timeBoxes = timeBoxRepository.findTableTimeBoxes(table);
         table.updateUsedAt();
 
@@ -67,8 +62,7 @@ public class CustomizeService {
 
     @Transactional
     public void deleteTable(long tableId, Member member) {
-        CustomizeTable table = tableRepository.findByIdAndMember(tableId, member)
-                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+        CustomizeTable table = tableRepository.getByIdAndMember(tableId, member);
         timeBoxRepository.deleteAllByTable(table);
         tableRepository.delete(table);
     }

--- a/src/test/java/com/debatetimer/repository/customize/CustomizeTableRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/customize/CustomizeTableRepositoryTest.java
@@ -1,9 +1,12 @@
 package com.debatetimer.repository.customize;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import com.debatetimer.repository.BaseRepositoryTest;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
@@ -29,6 +32,31 @@ class CustomizeTableRepositoryTest extends BaseRepositoryTest {
             List<CustomizeTable> foundKeoChanTables = tableRepository.findAllByMember(chan);
 
             assertThat(foundKeoChanTables).containsExactly(chanTable1, chanTable2);
+        }
+    }
+
+    @Nested
+    class GetByIdAndMember {
+
+        @Test
+        void 특정_회원의_테이블을_조회한다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            CustomizeTable table = customizeTableGenerator.generate(chan);
+
+            CustomizeTable foundTable = tableRepository.getByIdAndMember(table.getId(), chan);
+
+            assertThat(foundTable).isEqualTo(table);
+        }
+
+        @Test
+        void 존재하지_않는_테이블을_조회하면_예외를_던진다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            customizeTableGenerator.generate(chan);
+            long nonExistTableId = 99999999L;
+
+            assertThatThrownBy(() -> tableRepository.getByIdAndMember(nonExistTableId, chan))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessageContaining(ClientErrorCode.TABLE_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.debatetimer.repository.customize;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import com.debatetimer.domain.customize.CustomizeBoxType;
 import com.debatetimer.domain.customize.CustomizeTable;
@@ -51,6 +52,30 @@ class CustomizeTimeBoxRepositoryTest extends BaseRepositoryTest {
 
             List<CustomizeTimeBox> timeBoxes = customizeTimeBoxRepository.findAllByCustomizeTable(chanTable);
             assertThat(timeBoxes).isEmpty();
+        }
+
+        @Test
+        void 특정_테이블의_타임_박스를_삭제해도_다른_테이블의_타임_박스는_삭제되지_않는다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            CustomizeTable filledTable = customizeTableGenerator.generate(chan);
+            customizeTimeBoxGenerator.generate(filledTable, CustomizeBoxType.NORMAL, 1);
+            customizeTimeBoxGenerator.generate(filledTable, CustomizeBoxType.NORMAL, 2);
+            CustomizeTable deletedTable = customizeTableGenerator.generate(chan);
+            customizeTimeBoxGenerator.generate(deletedTable, CustomizeBoxType.NORMAL, 1);
+
+            customizeTimeBoxRepository.deleteAllByTable(deletedTable);
+
+            List<CustomizeTimeBox> timeBoxes = customizeTimeBoxRepository.findAllByCustomizeTable(filledTable);
+            assertThat(timeBoxes).hasSize(2);
+        }
+
+        @Test
+        void 테이블의_타임_박스가_없을_경우_타임_박스_삭제_시_예외가_발생하지_않는다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            CustomizeTable emptyTable = customizeTableGenerator.generate(chan);
+
+            assertThatCode(() -> customizeTimeBoxRepository.deleteAllByTable(emptyTable))
+                    .doesNotThrowAnyException();
         }
     }
 }

--- a/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
@@ -36,4 +36,21 @@ class CustomizeTimeBoxRepositoryTest extends BaseRepositoryTest {
             assertThat(foundBoxes).containsExactly(chanBox1, chanBox2);
         }
     }
+
+    @Nested
+    class DeleteAllByTable {
+
+        @Test
+        void 특정_테이블의_타임박스를_모두_삭제한다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            CustomizeTable chanTable = customizeTableGenerator.generate(chan);
+            customizeTimeBoxGenerator.generate(chanTable, CustomizeBoxType.NORMAL, 1);
+            customizeTimeBoxGenerator.generate(chanTable, CustomizeBoxType.NORMAL, 2);
+
+            customizeTimeBoxRepository.deleteAllByTable(chanTable);
+
+            List<CustomizeTimeBox> timeBoxes = customizeTimeBoxRepository.findAllByCustomizeTable(chanTable);
+            assertThat(timeBoxes).isEmpty();
+        }
+    }
 }


### PR DESCRIPTION
# 🚩 연관 이슈
closed #183 

# 🗣️ 리뷰 요구사항 (선택)
- 디스코드에서 이야기 한 내용 반영해서 리팩토링 진행했습니다~
- 실험해보고 싶으면 [제 실험용 레포지토리](https://github.com/leegwichan/spring-concurrency) 참고하세요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 특정 테이블에 연관된 타임박스를 일괄 삭제하는 방식을 도입하여 삭제 과정을 간소화했습니다.
  - 타임박스 업데이트 및 삭제 시 잠금과 중간 조회 과정을 제거했습니다.
  - 특정 회원과 테이블 ID로 테이블을 조회하는 새로운 방식이 추가되었습니다.

- **Tests**
  - 특정 테이블에 속한 모든 타임박스 일괄 삭제 기능에 대한 테스트를 추가했습니다.
  - 특정 회원의 테이블 조회 및 존재하지 않는 테이블 조회 시 예외 발생 여부를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->