### PR TITLE
[REFACTOR] 타임박스 도메인 - 엔티티 분리 / 도메인 구현

### DIFF
--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomain.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomain.java
@@ -27,7 +27,7 @@ public abstract class CustomizeTimeBoxDomain {
     }
 
     private void validateStance(Stance stance) {
-        if (!isValidStance(stance)) {
+        if (stance == null || !isValidStance(stance)) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_STANCE);
         }
     }

--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomain.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomain.java
@@ -1,0 +1,72 @@
+package com.debatetimer.domain.customize;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.springframework.lang.Nullable;
+
+public abstract class CustomizeTimeBoxDomain {
+
+    public static final int SPEECH_TYPE_MAX_LENGTH = 10;
+    public static final int SPEAKER_MAX_LENGTH = 5;
+
+    private final Stance stance;
+
+    private final String speechType;
+
+    @Nullable
+    private final String speaker;
+
+    protected CustomizeTimeBoxDomain(Stance stance, String speechType, @Nullable String speaker) {
+        validateStance(stance);
+        validateSpeechType(speechType);
+        validateSpeaker(speaker);
+
+        this.stance = stance;
+        this.speechType = speechType;
+        this.speaker = speaker;
+    }
+
+    private void validateStance(Stance stance) {
+        if (!isValidStance(stance)) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_STANCE);
+        }
+    }
+
+    protected abstract boolean isValidStance(Stance stance);
+
+    private void validateSpeechType(String speechType) {
+        if (speechType == null || speechType.isBlank() || speechType.length() > SPEECH_TYPE_MAX_LENGTH) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_SPEECH_TYPE_LENGTH);
+        }
+    }
+
+    private void validateSpeaker(String speaker) {
+        if (speaker != null && speaker.length() > SPEAKER_MAX_LENGTH) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_SPEAKER_LENGTH);
+        }
+    }
+
+    public final Stance getStance() {
+        return stance;
+    }
+
+    public final String getSpeechType() {
+        return speechType;
+    }
+
+    @Nullable
+    public final String getSpeaker() {
+        return speaker;
+    }
+
+    public abstract CustomizeBoxType getBoxType();
+
+    @Nullable
+    public abstract Integer getTime();
+
+    @Nullable
+    public abstract Integer getTimePerTeam();
+
+    @Nullable
+    public abstract Integer getTimePerSpeaking();
+}

--- a/src/main/java/com/debatetimer/domain/customize/NormalTimeBoxDomain.java
+++ b/src/main/java/com/debatetimer/domain/customize/NormalTimeBoxDomain.java
@@ -1,0 +1,50 @@
+package com.debatetimer.domain.customize;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.springframework.lang.Nullable;
+
+public final class NormalTimeBoxDomain extends CustomizeTimeBoxDomain {
+
+    private final int time;
+
+    public NormalTimeBoxDomain(Stance stance, String speechType, @Nullable String speaker, Integer time) {
+        super(stance, speechType, speaker);
+
+        validateTime(time);
+        this.time = time;
+    }
+
+    private void validateTime(Integer time) {
+        if (time == null || time <= 0) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
+        }
+    }
+
+    @Override
+    protected boolean isValidStance(Stance stance) {
+        return true;
+    }
+
+    @Override
+    public CustomizeBoxType getBoxType() {
+        return CustomizeBoxType.NORMAL;
+    }
+
+    @Override
+    public Integer getTime() {
+        return time;
+    }
+
+    @Nullable
+    @Override
+    public Integer getTimePerTeam() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public Integer getTimePerSpeaking() {
+        return null;
+    }
+}

--- a/src/main/java/com/debatetimer/domain/customize/Stance.java
+++ b/src/main/java/com/debatetimer/domain/customize/Stance.java
@@ -5,4 +5,9 @@ public enum Stance {
     PROS,
     CONS,
     NEUTRAL,
+    ;
+
+    public boolean isNeutralStance() {
+        return this == NEUTRAL;
+    }
 }

--- a/src/main/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomain.java
+++ b/src/main/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomain.java
@@ -24,19 +24,21 @@ public class TimeBasedTimeBoxDomain extends CustomizeTimeBoxDomain {
     }
 
     private void validateTimes(Integer timePerTeam, Integer timePerSpeaking) {
-        validateTime(timePerTeam);
-        if (timePerSpeaking == null) {
-            return;
-        }
-
-        validateTime(timePerSpeaking);
-        if (timePerTeam < timePerSpeaking) {
+        validateTimePerTeam(timePerTeam);
+        validateTimePerSpeaking(timePerSpeaking);
+        if (timePerSpeaking != null && timePerTeam < timePerSpeaking) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME);
         }
     }
 
-    private void validateTime(Integer time) {
+    private void validateTimePerTeam(Integer time) {
         if (time == null || time <= 0) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
+        }
+    }
+
+    private void validateTimePerSpeaking(Integer timePerSpeaking) {
+        if (timePerSpeaking != null && timePerSpeaking <= 0) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
         }
     }

--- a/src/main/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomain.java
+++ b/src/main/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomain.java
@@ -1,0 +1,70 @@
+package com.debatetimer.domain.customize;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.springframework.lang.Nullable;
+
+public class TimeBasedTimeBoxDomain extends CustomizeTimeBoxDomain {
+
+    private final int timePerTeam;
+
+    @Nullable
+    private final Integer timePerSpeaking;
+
+    public TimeBasedTimeBoxDomain(Stance stance,
+                                  String speechType,
+                                  @Nullable String speaker,
+                                  Integer timePerTeam,
+                                  @Nullable Integer timePerSpeaking) {
+        super(stance, speechType, speaker);
+
+        validateTimes(timePerTeam, timePerSpeaking);
+        this.timePerTeam = timePerTeam;
+        this.timePerSpeaking = timePerSpeaking;
+    }
+
+    private void validateTimes(Integer timePerTeam, Integer timePerSpeaking) {
+        validateTime(timePerTeam);
+        if (timePerSpeaking == null) {
+            return;
+        }
+
+        validateTime(timePerSpeaking);
+        if (timePerTeam < timePerSpeaking) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BASED_TIME);
+        }
+    }
+
+    private void validateTime(Integer time) {
+        if (time == null || time <= 0) {
+            throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_TIME);
+        }
+    }
+
+    @Override
+    protected boolean isValidStance(Stance stance) {
+        return stance.isNeutralStance();
+    }
+
+    @Override
+    public CustomizeBoxType getBoxType() {
+        return CustomizeBoxType.TIME_BASED;
+    }
+
+    @Override
+    @Nullable
+    public Integer getTime() {
+        return null;
+    }
+
+    @Override
+    public Integer getTimePerTeam() {
+        return timePerTeam;
+    }
+
+    @Override
+    @Nullable
+    public Integer getTimePerSpeaking() {
+        return timePerSpeaking;
+    }
+}

--- a/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomainTest.java
@@ -1,0 +1,98 @@
+package com.debatetimer.domain.customize;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CustomizeTimeBoxDomainTest {
+
+    @Nested
+    class ValidateSpeechType {
+
+        @Test
+        void 발언_종류는_특정_글자를_초과할_수_없다() {
+            String speechType = "a".repeat(CustomizeTimeBoxDomain.SPEECH_TYPE_MAX_LENGTH + 1);
+
+            assertThatThrownBy(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, speechType, "비토"))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SPEECH_TYPE_LENGTH.getMessage());
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "\n\t"})
+        void 발언_종류는_비어있을_수_없다(String emptySpeechType) {
+            assertThatThrownBy(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, emptySpeechType, "비토"))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SPEECH_TYPE_LENGTH.getMessage());
+        }
+
+        @Test
+        void 발언_종류는_특정_글자_이내이어야_한다() {
+            String speechType = "a".repeat(CustomizeTimeBoxDomain.SPEECH_TYPE_MAX_LENGTH);
+
+            assertThatCode(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, speechType, "비토"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ValidateSpeaker {
+
+        @Test
+        void 발언자_이름은_특정_글자를_초과할_수_없다() {
+            String speaker = "a".repeat(CustomizeTimeBoxDomain.SPEAKER_MAX_LENGTH + 1);
+
+            assertThatThrownBy(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, "비토", speaker))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_SPEAKER_LENGTH.getMessage());
+        }
+
+        @Test
+        void 발언자_이름은_비어있을_수_있다() {
+            assertThatCode(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, "비토", null))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+
+
+    static class InheritedCustomizeTimeBoxDomain extends CustomizeTimeBoxDomain {
+
+        protected InheritedCustomizeTimeBoxDomain(Stance stance, String speechType, String speaker) {
+            super(stance, speechType, speaker);
+        }
+
+        @Override
+        protected boolean isValidStance(Stance stance) {
+            return true;
+        }
+
+        @Override
+        public CustomizeBoxType getBoxType() {
+            return null;
+        }
+
+        @Override
+        public Integer getTime() {
+            return 0;
+        }
+
+        @Override
+        public Integer getTimePerTeam() {
+            return 0;
+        }
+
+        @Override
+        public Integer getTimePerSpeaking() {
+            return 0;
+        }
+    }
+}

--- a/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/CustomizeTimeBoxDomainTest.java
@@ -14,6 +14,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 class CustomizeTimeBoxDomainTest {
 
     @Nested
+    class ValidateStance {
+
+        @Test
+        void 발언_입장은_비어있을_수_없다() {
+            assertThatThrownBy(() -> new InheritedCustomizeTimeBoxDomain(null, "비토", "발언자"))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_STANCE.getMessage());
+        }
+
+        @Test
+        void 발언_입장은_유효한_값이어야_한다() {
+            assertThatCode(() -> new InheritedCustomizeTimeBoxDomain(Stance.PROS, "비토", "발언자"))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
     class ValidateSpeechType {
 
         @Test
@@ -61,8 +78,6 @@ class CustomizeTimeBoxDomainTest {
                     .doesNotThrowAnyException();
         }
     }
-
-
 
     static class InheritedCustomizeTimeBoxDomain extends CustomizeTimeBoxDomain {
 

--- a/src/test/java/com/debatetimer/domain/customize/NormalTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/NormalTimeBoxDomainTest.java
@@ -1,0 +1,43 @@
+package com.debatetimer.domain.customize;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NormalTimeBoxDomainTest {
+
+    @Nested
+    class ValidateTime {
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+        void 시간은_0보다_커야_한다(int time) {
+            assertThatThrownBy(() -> new NormalTimeBoxDomain(Stance.PROS, "비토", null, time))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
+        }
+
+        @Test
+        void 시간은_비어있지_않아야_한다() {
+            Integer time = null;
+
+            assertThatThrownBy(() -> new NormalTimeBoxDomain(Stance.PROS, "비토", null, time))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
+        }
+
+        @Test
+        void 시간은_양수여야_한다() {
+            int time = 1;
+
+            assertThatCode(() -> new NormalTimeBoxDomain(Stance.PROS, "비토", null, time))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/debatetimer/domain/customize/NormalTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/NormalTimeBoxDomainTest.java
@@ -7,17 +7,16 @@ import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class NormalTimeBoxDomainTest {
 
     @Nested
     class ValidateTime {
 
-        @ParameterizedTest
-        @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
-        void 시간은_0보다_커야_한다(int time) {
+        @Test
+        void 시간은_0보다_커야_한다() {
+            Integer time = 0;
+
             assertThatThrownBy(() -> new NormalTimeBoxDomain(Stance.PROS, "비토", null, time))
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
@@ -34,7 +33,7 @@ class NormalTimeBoxDomainTest {
 
         @Test
         void 시간은_양수여야_한다() {
-            int time = 1;
+            Integer time = 1;
 
             assertThatCode(() -> new NormalTimeBoxDomain(Stance.PROS, "비토", null, time))
                     .doesNotThrowAnyException();

--- a/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
@@ -7,8 +7,6 @@ import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class TimeBasedTimeBoxDomainTest {
 
@@ -38,9 +36,9 @@ class TimeBasedTimeBoxDomainTest {
     @Nested
     class ValidateTimes {
 
-        @ParameterizedTest
-        @ValueSource(ints = {0, -1, -100})
-        void 팀_당_발언_시간이_양수이어야_한다(int timePerTeam) {
+        @Test
+        void 팀_당_발언_시간이_양수이어야_한다() {
+            int timePerTeam = 0;
             int timePerSpeaking = 1;
 
             assertThatThrownBy(
@@ -60,9 +58,9 @@ class TimeBasedTimeBoxDomainTest {
                     .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
         }
 
-        @ParameterizedTest
-        @ValueSource(ints = {0, -1, -100})
-        void 개인_당_시간이_양수이어야_한다(int timePerSpeaking) {
+        @Test
+        void 개인_당_시간이_양수이어야_한다() {
+            int timePerSpeaking = 0;
             int timePerTeam = 1;
 
             assertThatThrownBy(
@@ -81,9 +79,9 @@ class TimeBasedTimeBoxDomainTest {
                     .doesNotThrowAnyException();
         }
 
-        @ParameterizedTest
-        @ValueSource(ints = {1, 60, 120})
-        void 팀_당_발언시간은_개인_발언시간보다_많거나_같아야_한다(int timePerTeam) {
+        @Test
+        void 팀_당_발언시간은_개인_발언시간보다_많거나_같아야_한다() {
+            int timePerTeam = 60;
             int timePerSpeaking = timePerTeam + 1;
 
             assertThatThrownBy(

--- a/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
@@ -59,7 +59,7 @@ class TimeBasedTimeBoxDomainTest {
         }
 
         @Test
-        void 개인_당_시간이_양수이어야_한다() {
+        void 회_당_시간이_양수이어야_한다() {
             int timePerSpeaking = 0;
             int timePerTeam = 1;
 
@@ -70,7 +70,7 @@ class TimeBasedTimeBoxDomainTest {
         }
 
         @Test
-        void 개인_당_발언_시간은_비어있을_수_있다() {
+        void 회_당_발언_시간은_비어있을_수_있다() {
             Integer timePerSpeaking = null;
             int timePerTeam = 1;
 
@@ -80,7 +80,7 @@ class TimeBasedTimeBoxDomainTest {
         }
 
         @Test
-        void 팀_당_발언시간은_개인_발언시간보다_많거나_같아야_한다() {
+        void 팀_당_발언시간은_회_당_발언시간보다_많거나_같아야_한다() {
             int timePerTeam = 60;
             int timePerSpeaking = timePerTeam + 1;
 

--- a/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
@@ -1,0 +1,95 @@
+package com.debatetimer.domain.customize;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TimeBasedTimeBoxDomainTest {
+
+    @Nested
+    class ValidateStance {
+
+        @Test
+        void 중립_스탠스가_아니면_예외가_발생한다() {
+            Stance stance = Stance.PROS;
+
+            assertThatThrownBy(
+                    () -> new TimeBasedTimeBoxDomain(stance, "자유발언", "비토", 120, 60))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_STANCE.getMessage());
+        }
+
+        @Test
+        void 중립_스탠스면_예외가_발생하지_않는다() {
+            Stance stance = Stance.NEUTRAL;
+
+            assertThatCode(
+                    () -> new TimeBasedTimeBoxDomain(stance, "자유발언", "비토", 120, 60))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    @Nested
+    class ValidateTimes {
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100})
+        void 팀_당_발언_시간이_양수이어야_한다(int timePerTeam) {
+            int timePerSpeaking = 1;
+
+            assertThatThrownBy(
+                    () -> new TimeBasedTimeBoxDomain(Stance.NEUTRAL, "자유발언", "비토", timePerTeam, timePerSpeaking))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
+        }
+
+        @Test
+        void 팀_당_발언_시간이_비어있으면_안된다() {
+            Integer timePerTeam = null;
+            int timePerSpeaking = 1;
+
+            assertThatThrownBy(
+                    () -> new TimeBasedTimeBoxDomain(Stance.NEUTRAL, "자유발언", "비토", timePerTeam, timePerSpeaking))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0, -1, -100})
+        void 개인_당_시간이_양수이어야_한다(int timePerSpeaking) {
+            int timePerTeam = 1;
+
+            assertThatThrownBy(
+                    () -> new TimeBasedTimeBoxDomain(Stance.NEUTRAL, "자유발언", "비토", timePerTeam, timePerSpeaking))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BOX_TIME.getMessage());
+        }
+
+        @Test
+        void 개인_당_발언_시간은_비어있을_수_있다() {
+            Integer timePerSpeaking = null;
+            int timePerTeam = 1;
+
+            assertThatCode(
+                    () -> new TimeBasedTimeBoxDomain(Stance.NEUTRAL, "자유발언", "비토", timePerTeam, timePerSpeaking))
+                    .doesNotThrowAnyException();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {1, 60, 120})
+        void 팀_당_발언시간은_개인_발언시간보다_많거나_같아야_한다(int timePerTeam) {
+            int timePerSpeaking = timePerTeam + 1;
+
+            assertThatThrownBy(
+                    () -> new TimeBasedTimeBoxDomain(Stance.NEUTRAL, "자유발언", "비토", timePerTeam, timePerSpeaking))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.INVALID_TIME_BASED_TIME.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
+++ b/src/test/java/com/debatetimer/domain/customize/TimeBasedTimeBoxDomainTest.java
@@ -1,7 +1,7 @@
 package com.debatetimer.domain.customize;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;


### PR DESCRIPTION
# 🚩 연관 이슈
#191 

# 🗣️ 리뷰 요구사항 (선택)
- 한번에 리뷰 받으면 PR 무거워 질 것 같아서 1차적으로 도메인 구현 관련해서만 리뷰 받습니다~
- 비토 PR 머지된 이후에, 클래스 네이밍 변경 예정입니다~ (`XXXDomain` -> `XXX`, `XXX` -> `XXXEntity`)
- 비토 PR 머지된 이후에, DTO, Entity 연결 로직 작성하고, TableServiceV2도 리팩토링 할 예정입니다~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 커스터마이즈 가능한 타임박스 도메인 및 다양한 타임박스 유형(일반, 시간 기반) 도입
  * 스탠스(입장) 관련 메서드 및 중립 스탠스 확인 기능 추가

* **버그 수정**
  * 입력값(스피치 타입, 발표자, 시간 등)에 대한 유효성 검사 및 예외 처리 강화

* **테스트**
  * 커스터마이즈 타임박스, 일반 타임박스, 시간 기반 타임박스의 입력값 검증을 위한 테스트 케이스 추가 및 검증 로직 테스트 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->