### PR TITLE
[REFACTOR] 타임박스 도메인 - 엔티티 분리 / 서비스 로직 개선

### DIFF
--- a/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxEntities.java
+++ b/src/main/java/com/debatetimer/domain/customize/CustomizeTimeBoxEntities.java
@@ -1,21 +1,46 @@
 package com.debatetimer.domain.customize;
 
+import com.debatetimer.entity.customize.BellEntity;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import lombok.Getter;
 
-@Getter
 public class CustomizeTimeBoxEntities {
 
     private static final Comparator<CustomizeTimeBoxEntity> TIME_BOX_COMPARATOR = Comparator
             .comparing(CustomizeTimeBoxEntity::getSequence);
 
+    @Getter
     private final List<CustomizeTimeBoxEntity> timeBoxes;
+
+    private final List<BellEntity> bells;
 
     public CustomizeTimeBoxEntities(List<CustomizeTimeBoxEntity> timeBoxes) {
         this.timeBoxes = timeBoxes.stream()
                 .sorted(TIME_BOX_COMPARATOR)
+                .toList();
+        this.bells = Collections.emptyList();
+    }
+
+    public CustomizeTimeBoxEntities(List<CustomizeTimeBoxEntity> timeBoxes, List<BellEntity> bells) {
+        this.timeBoxes = timeBoxes.stream()
+                .sorted(TIME_BOX_COMPARATOR)
+                .toList();
+        this.bells = bells;
+    }
+
+    public List<CustomizeTimeBox> toDomain() {
+        return timeBoxes.stream()
+                .map(timebox -> timebox.toDomain(getBells(timebox)))
+                .toList();
+    }
+
+    private List<Bell> getBells(CustomizeTimeBoxEntity timeBox) {
+        return bells.stream()
+                .filter(bell -> bell.isContained(timeBox))
+                .map(BellEntity::toDomain)
                 .toList();
     }
 }

--- a/src/main/java/com/debatetimer/dto/customize/request/CustomizeTableCreateRequest.java
+++ b/src/main/java/com/debatetimer/dto/customize/request/CustomizeTableCreateRequest.java
@@ -2,7 +2,7 @@ package com.debatetimer.dto.customize.request;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.customize.CustomizeTimeBox;
-import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.domain.member.Member;
 import jakarta.validation.Valid;
 import java.util.List;

--- a/src/main/java/com/debatetimer/dto/customize/response/CustomizeTableResponse.java
+++ b/src/main/java/com/debatetimer/dto/customize/response/CustomizeTableResponse.java
@@ -2,7 +2,7 @@ package com.debatetimer.dto.customize.response;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.customize.CustomizeTimeBox;
-import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import java.util.List;
 

--- a/src/main/java/com/debatetimer/dto/customize/response/CustomizeTableResponse.java
+++ b/src/main/java/com/debatetimer/dto/customize/response/CustomizeTableResponse.java
@@ -16,13 +16,6 @@ public record CustomizeTableResponse(long id, CustomizeTableInfoResponse info, L
                 toTimeBoxResponses(customizeTimeBoxes));
     }
 
-    public CustomizeTableResponse(
-            CustomizeTable customizeTable,
-            List<CustomizeTimeBoxResponse> timeBoxResponses
-    ) {
-        this(customizeTable.getId(), new CustomizeTableInfoResponse(customizeTable), timeBoxResponses);
-    }
-
     private static List<CustomizeTimeBoxResponse> toTimeBoxResponses(CustomizeTimeBoxEntities timeBoxes) {
         List<CustomizeTimeBoxEntity> customizeTimeBoxes = timeBoxes.getTimeBoxes();
         return customizeTimeBoxes
@@ -31,13 +24,11 @@ public record CustomizeTableResponse(long id, CustomizeTableInfoResponse info, L
                 .toList();
     }
 
-    public static CustomizeTableResponse ofDomain(CustomizeTable customizeTable,
-                                                  List<CustomizeTimeBox> customizeTimeBoxes) { // TODO 정팩매 -> 생성자로 전환
-        return new CustomizeTableResponse(
-                customizeTable.getId(),
+    public CustomizeTableResponse(CustomizeTable customizeTable,
+                                  List<CustomizeTimeBox> customizeTimeBoxes) {
+        this(customizeTable.getId(),
                 new CustomizeTableInfoResponse(customizeTable),
-                toTimeBoxResponses(customizeTimeBoxes)
-        );
+                toTimeBoxResponses(customizeTimeBoxes));
     }
 
     private static List<CustomizeTimeBoxResponse> toTimeBoxResponses(List<CustomizeTimeBox> customizeTimeBoxes) {

--- a/src/main/java/com/debatetimer/dto/customize/response/CustomizeTimeBoxResponse.java
+++ b/src/main/java/com/debatetimer/dto/customize/response/CustomizeTimeBoxResponse.java
@@ -5,7 +5,6 @@ import com.debatetimer.domain.customize.CustomizeBoxType;
 import com.debatetimer.domain.customize.CustomizeTimeBox;
 import com.debatetimer.domain.customize.Stance;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
-import java.util.Collections;
 import java.util.List;
 
 public record CustomizeTimeBoxResponse(
@@ -26,19 +25,6 @@ public record CustomizeTimeBoxResponse(
                 customizeTimeBox.getBoxType(),
                 convertTime(customizeTimeBox),
                 null,
-                customizeTimeBox.getTimePerTeam(),
-                customizeTimeBox.getTimePerSpeaking(),
-                customizeTimeBox.getSpeaker()
-        );
-    }
-
-    public CustomizeTimeBoxResponse(CustomizeTimeBoxEntity customizeTimeBox, List<BellResponse> bell) {
-        this(
-                customizeTimeBox.getStance(),
-                customizeTimeBox.getSpeechType(),
-                customizeTimeBox.getBoxType(),
-                convertTime(customizeTimeBox),
-                bell,
                 customizeTimeBox.getTimePerTeam(),
                 customizeTimeBox.getTimePerSpeaking(),
                 customizeTimeBox.getSpeaker()

--- a/src/main/java/com/debatetimer/entity/customize/BellEntity.java
+++ b/src/main/java/com/debatetimer/entity/customize/BellEntity.java
@@ -1,5 +1,6 @@
 package com.debatetimer.entity.customize;
 
+import com.debatetimer.domain.customize.Bell;
 import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
 import jakarta.persistence.Column;
@@ -46,6 +47,12 @@ public class BellEntity {
         this.count = count;
     }
 
+    public BellEntity(CustomizeTimeBoxEntity customizeTimeBox, Bell bell) {
+        this.customizeTimeBox = customizeTimeBox;
+        this.time = bell.getTime();
+        this.count = bell.getCount();
+    }
+
     private void validateTime(int time) {
         if (time < 0) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_BELL_TIME);
@@ -56,5 +63,13 @@ public class BellEntity {
         if (count <= 0 || count > MAX_BELL_COUNT) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_BELL_COUNT);
         }
+    }
+
+    public Bell toDomain() {
+        return new Bell(time, count);
+    }
+
+    public boolean isContained(CustomizeTimeBoxEntity timeBox) {
+        return this.customizeTimeBox.getId().equals(timeBox.getId());
     }
 }

--- a/src/main/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntities.java
+++ b/src/main/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntities.java
@@ -1,7 +1,7 @@
-package com.debatetimer.domain.customize;
+package com.debatetimer.entity.customize;
 
-import com.debatetimer.entity.customize.BellEntity;
-import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
+import com.debatetimer.domain.customize.Bell;
+import com.debatetimer.domain.customize.CustomizeTimeBox;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;

--- a/src/main/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntity.java
+++ b/src/main/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntity.java
@@ -1,7 +1,11 @@
 package com.debatetimer.entity.customize;
 
+import com.debatetimer.domain.customize.Bell;
 import com.debatetimer.domain.customize.CustomizeBoxType;
+import com.debatetimer.domain.customize.CustomizeTimeBox;
+import com.debatetimer.domain.customize.NormalTimeBox;
 import com.debatetimer.domain.customize.Stance;
+import com.debatetimer.domain.customize.TimeBasedTimeBox;
 import com.debatetimer.exception.custom.DTClientErrorException;
 import com.debatetimer.exception.errorcode.ClientErrorCode;
 import jakarta.persistence.Entity;
@@ -16,6 +20,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,7 +50,7 @@ public class CustomizeTimeBoxEntity {
     @Enumerated(EnumType.STRING)
     private Stance stance;
 
-    private int time;
+    private Integer time;
     private String speaker;
 
     @NotBlank
@@ -108,6 +113,18 @@ public class CustomizeTimeBoxEntity {
         this.boxType = boxType;
         this.timePerTeam = timePerTeam;
         this.timePerSpeaking = timePerSpeaking;
+    }
+
+    public CustomizeTimeBoxEntity(CustomizeTableEntity customizeTable, CustomizeTimeBox timeBox, int sequence) {
+        this.customizeTable = customizeTable;
+        this.sequence = sequence;
+        this.stance = timeBox.getStance();
+        this.time = timeBox.getTime();
+        this.speaker = timeBox.getSpeaker();
+        this.speechType = timeBox.getSpeechType();
+        this.boxType = timeBox.getBoxType();
+        this.timePerTeam = timeBox.getTimePerTeam();
+        this.timePerSpeaking = timeBox.getTimePerSpeaking();
     }
 
     private static int convertToTime(Integer timePerTeam) {
@@ -177,5 +194,12 @@ public class CustomizeTimeBoxEntity {
         if (speechType.length() > SPEECH_TYPE_MAX_LENGTH) {
             throw new DTClientErrorException(ClientErrorCode.INVALID_TIME_BOX_SPEECH_TYPE_LENGTH);
         }
+    }
+
+    public CustomizeTimeBox toDomain(List<Bell> bells) {
+        if (boxType.isTimeBased()) {
+            return new TimeBasedTimeBox(stance, speechType, speaker, timePerTeam, timePerSpeaking);
+        }
+        return new NormalTimeBox(stance, speechType, speaker, time, bells);
     }
 }

--- a/src/main/java/com/debatetimer/repository/customize/BellRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/BellRepository.java
@@ -3,15 +3,17 @@ package com.debatetimer.repository.customize;
 import com.debatetimer.entity.customize.BellEntity;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface BellRepository extends Repository<BellEntity, Long> {
 
     BellEntity save(BellEntity bell);
 
-    List<BellEntity> findByCustomizeTimeBox(CustomizeTimeBoxEntity customizeTimeBox);
-
-    void deleteAllByCustomizeTimeBoxIn(List<CustomizeTimeBoxEntity> customizeTimeBoxes);
+    @Query("DELETE FROM BellEntity b WHERE b.customizeTimeBox.customizeTable.id = :tableId")
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    void deleteAllByTable(long tableId);
 
     List<BellEntity> findAllByCustomizeTimeBoxIn(List<CustomizeTimeBoxEntity> timeBoxes);
 }

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
@@ -27,7 +27,7 @@ public interface CustomizeTimeBoxRepository extends Repository<CustomizeTimeBoxE
         return new CustomizeTimeBoxEntities(timeBoxes);
     }
 
-    @Query("DELETE FROM CustomizeTimeBoxEntity ctb WHERE ctb.customizeTable = :table")
+    @Query("DELETE FROM CustomizeTimeBoxEntity ctb WHERE ctb.customizeTable.id = :tableId")
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    void deleteAllByTable(CustomizeTableEntity table);
+    void deleteAllByTable(long tableId);
 }

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepository.java
@@ -1,7 +1,7 @@
 package com.debatetimer.repository.customize;
 
-import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.entity.customize.CustomizeTableEntity;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.Modifying;

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -47,7 +47,7 @@ public class CustomizeService {
         CustomizeTable renewedTable = tableCreateRequest.toTable(member);
         existingTable.updateTable(renewedTable);
 
-        timeBoxRepository.deleteAllByTable(existingTable);
+        timeBoxRepository.deleteAllByTable(existingTable.getId());
         CustomizeTimeBoxEntities savedCustomizeTimeBoxes = saveTimeBoxes(tableCreateRequest, existingTable.toDomain());
         return new CustomizeTableResponse(existingTable.toDomain(), savedCustomizeTimeBoxes);
     }
@@ -64,7 +64,7 @@ public class CustomizeService {
     @Transactional
     public void deleteTable(long tableId, Member member) {
         CustomizeTableEntity table = tableRepository.getByIdAndMember(tableId, member);
-        timeBoxRepository.deleteAllByTable(table);
+        timeBoxRepository.deleteAllByTable(table.getId());
         tableRepository.delete(table);
     }
 

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -1,11 +1,11 @@
 package com.debatetimer.service.customize;
 
 import com.debatetimer.domain.customize.CustomizeTable;
-import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.domain.member.Member;
 import com.debatetimer.dto.customize.request.CustomizeTableCreateRequest;
 import com.debatetimer.dto.customize.response.CustomizeTableResponse;
 import com.debatetimer.entity.customize.CustomizeTableEntity;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import com.debatetimer.repository.customize.CustomizeTableRepository;
 import com.debatetimer.repository.customize.CustomizeTimeBoxRepository;

--- a/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
@@ -1,14 +1,11 @@
 package com.debatetimer.service.customize;
 
 import com.debatetimer.domain.customize.CustomizeTable;
+import com.debatetimer.domain.customize.CustomizeTimeBox;
 import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.domain.member.Member;
-import com.debatetimer.dto.customize.request.BellRequest;
 import com.debatetimer.dto.customize.request.CustomizeTableCreateRequest;
-import com.debatetimer.dto.customize.request.CustomizeTimeBoxCreateRequest;
-import com.debatetimer.dto.customize.response.BellResponse;
 import com.debatetimer.dto.customize.response.CustomizeTableResponse;
-import com.debatetimer.dto.customize.response.CustomizeTimeBoxResponse;
 import com.debatetimer.entity.customize.BellEntity;
 import com.debatetimer.entity.customize.CustomizeTableEntity;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
@@ -32,20 +29,21 @@ public class CustomizeServiceV2 {
     @Transactional
     public CustomizeTableResponse save(CustomizeTableCreateRequest tableCreateRequest, Member member) {
         CustomizeTable table = tableCreateRequest.toTable(member);
-        CustomizeTableEntity savedTable = tableRepository.save(new CustomizeTableEntity(table));
+        List<CustomizeTimeBox> timeBoxes = tableCreateRequest.toTimeBoxList();
 
-        return saveTimeBoxesAndBells(tableCreateRequest, savedTable.toDomain());
+        CustomizeTableEntity savedTableEntity = tableRepository.save(new CustomizeTableEntity(table));
+        saveTimeBoxes(savedTableEntity, timeBoxes);
+        return CustomizeTableResponse.ofDomain(savedTableEntity.toDomain(), timeBoxes);
     }
 
     @Transactional(readOnly = true)
     public CustomizeTableResponse findTable(long tableId, Member member) {
         CustomizeTableEntity tableEntity = tableRepository.getByIdAndMember(tableId, member);
-        CustomizeTimeBoxEntities timeBoxes = timeBoxRepository.findTableTimeBoxes(tableEntity);
-        List<CustomizeTimeBoxResponse> timeBoxResponses = timeBoxes.getTimeBoxes()
-                .stream()
-                .map(this::getTimeBoxResponse)
-                .toList();
-        return new CustomizeTableResponse(tableEntity.toDomain(), timeBoxResponses);
+        List<CustomizeTimeBoxEntity> timeBoxEntityList = timeBoxRepository.findAllByCustomizeTable(tableEntity);
+        List<BellEntity> bellEntityList = bellRepository.findAllByCustomizeTimeBoxIn(timeBoxEntityList);
+        CustomizeTimeBoxEntities timeBoxEntities = new CustomizeTimeBoxEntities(timeBoxEntityList, bellEntityList);
+
+        return CustomizeTableResponse.ofDomain(tableEntity.toDomain(), timeBoxEntities.toDomain());
     }
 
     @Transactional
@@ -54,83 +52,47 @@ public class CustomizeServiceV2 {
             long tableId,
             Member member
     ) {
-        CustomizeTableEntity existingTable = tableRepository.getByIdAndMember(tableId, member);
-        CustomizeTable renewedTable = tableCreateRequest.toTable(member);
-        existingTable.updateTable(renewedTable);
+        CustomizeTableEntity tableEntity = tableRepository.getByIdAndMember(tableId, member);
+        bellRepository.deleteAllByTable(tableEntity.getId());
+        timeBoxRepository.deleteAllByTable(tableEntity.getId());
 
-        deleteBell(timeBoxRepository.findTableTimeBoxes(existingTable));
-        timeBoxRepository.deleteAllByTable(existingTable);
-        return saveTimeBoxesAndBells(tableCreateRequest, existingTable.toDomain());
+        tableEntity.updateTable(tableCreateRequest.toTable(member));
+        List<CustomizeTimeBox> timeBoxes = tableCreateRequest.toTimeBoxList();
+        saveTimeBoxes(tableEntity, timeBoxes);
+        return CustomizeTableResponse.ofDomain(tableEntity.toDomain(), timeBoxes);
     }
 
     @Transactional
     public CustomizeTableResponse updateUsedAt(long tableId, Member member) {
         CustomizeTableEntity tableEntity = tableRepository.getByIdAndMember(tableId, member);
-        CustomizeTimeBoxEntities timeBoxes = timeBoxRepository.findTableTimeBoxes(tableEntity);
+        List<CustomizeTimeBoxEntity> timeBoxEntityList = timeBoxRepository.findAllByCustomizeTable(tableEntity);
+        List<BellEntity> bellEntityList = bellRepository.findAllByCustomizeTimeBoxIn(timeBoxEntityList);
+        CustomizeTimeBoxEntities timeBoxEntities = new CustomizeTimeBoxEntities(timeBoxEntityList, bellEntityList);
+
         tableEntity.updateUsedAt();
-        List<CustomizeTimeBoxResponse> timeBoxResponses = timeBoxes.getTimeBoxes()
-                .stream()
-                .map(this::getTimeBoxResponse)
-                .toList();
-        return new CustomizeTableResponse(tableEntity.toDomain(), timeBoxResponses);
+        CustomizeTable table = tableEntity.toDomain();
+        List<CustomizeTimeBox> timeBoxes = timeBoxEntities.toDomain();
+        return CustomizeTableResponse.ofDomain(table, timeBoxes);
     }
 
     @Transactional
     public void deleteTable(long tableId, Member member) {
         CustomizeTableEntity table = tableRepository.getByIdAndMember(tableId, member);
 
-        deleteBell(timeBoxRepository.findTableTimeBoxes(table));
-        timeBoxRepository.deleteAllByTable(table);
+        bellRepository.deleteAllByTable(table.getId());
+        timeBoxRepository.deleteAllByTable(table.getId());
         tableRepository.delete(table);
     }
 
-    private CustomizeTableResponse saveTimeBoxesAndBells(
-            CustomizeTableCreateRequest tableCreateRequest,
-            CustomizeTable table
-    ) {
-        List<CustomizeTimeBoxCreateRequest> timeBoxCreateRequests = tableCreateRequest.table();
-        List<CustomizeTimeBoxResponse> timeBoxResponses = IntStream.range(0, timeBoxCreateRequests.size())
-                .mapToObj(i -> createTimeBoxResponse(timeBoxCreateRequests.get(i), table, i + 1))
-                .toList();
-        return new CustomizeTableResponse(table, timeBoxResponses);
+    private void saveTimeBoxes(CustomizeTableEntity tableEntity, List<CustomizeTimeBox> timeBoxes) {
+        IntStream.range(0, timeBoxes.size())
+                .forEach(i -> saveTimeBox(tableEntity, timeBoxes.get(i), i + 1));
     }
 
-    private CustomizeTimeBoxResponse createTimeBoxResponse(
-            CustomizeTimeBoxCreateRequest request,
-            CustomizeTable table,
-            int sequence
-    ) {
-        CustomizeTimeBoxEntity savedTimeBox = timeBoxRepository.save(request.toTimeBox(table, sequence));
-        return createTimeBoxResponse(request.bell(), savedTimeBox);
-    }
-
-    private CustomizeTimeBoxResponse createTimeBoxResponse(List<BellRequest> bellRequests, CustomizeTimeBoxEntity timeBox) {
-        if (timeBox.getBoxType().isTimeBased()) {
-            return new CustomizeTimeBoxResponse(timeBox, null);
-        }
-
-        List<BellResponse> bellResponses = bellRequests
-                .stream()
-                .map(bellRequest -> new BellEntity(timeBox, bellRequest.time(), bellRequest.count()))
-                .map(bellRepository::save)
-                .map(bell -> new BellResponse(bell.getTime(), bell.getCount()))
-                .toList();
-        return new CustomizeTimeBoxResponse(timeBox, bellResponses);
-    }
-
-    private CustomizeTimeBoxResponse getTimeBoxResponse(CustomizeTimeBoxEntity timeBox) {
-        if (timeBox.getBoxType().isTimeBased()) {
-            return new CustomizeTimeBoxResponse(timeBox, null);
-        }
-
-        List<BellResponse> bellResponses = bellRepository.findByCustomizeTimeBox(timeBox)
-                .stream()
-                .map(bell -> new BellResponse(bell.getTime(), bell.getCount()))
-                .toList();
-        return new CustomizeTimeBoxResponse(timeBox, bellResponses);
-    }
-
-    private void deleteBell(CustomizeTimeBoxEntities savedCustomizeTimeBoxes) {
-        bellRepository.deleteAllByCustomizeTimeBoxIn(savedCustomizeTimeBoxes.getTimeBoxes());
+    private void saveTimeBox(CustomizeTableEntity tableEntity, CustomizeTimeBox timeBox, int sequence) {
+        CustomizeTimeBoxEntity timeBoxEntity = timeBoxRepository.save(
+                new CustomizeTimeBoxEntity(tableEntity, timeBox, sequence));
+        timeBox.getBells()
+                .forEach(bell -> bellRepository.save(new BellEntity(timeBoxEntity, bell)));
     }
 }

--- a/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
@@ -33,7 +33,7 @@ public class CustomizeServiceV2 {
 
         CustomizeTableEntity savedTableEntity = tableRepository.save(new CustomizeTableEntity(table));
         saveTimeBoxes(savedTableEntity, timeBoxes);
-        return CustomizeTableResponse.ofDomain(savedTableEntity.toDomain(), timeBoxes);
+        return new CustomizeTableResponse(savedTableEntity.toDomain(), timeBoxes);
     }
 
     @Transactional(readOnly = true)
@@ -43,7 +43,7 @@ public class CustomizeServiceV2 {
         List<BellEntity> bellEntityList = bellRepository.findAllByCustomizeTimeBoxIn(timeBoxEntityList);
         CustomizeTimeBoxEntities timeBoxEntities = new CustomizeTimeBoxEntities(timeBoxEntityList, bellEntityList);
 
-        return CustomizeTableResponse.ofDomain(tableEntity.toDomain(), timeBoxEntities.toDomain());
+        return new CustomizeTableResponse(tableEntity.toDomain(), timeBoxEntities.toDomain());
     }
 
     @Transactional
@@ -59,7 +59,7 @@ public class CustomizeServiceV2 {
         timeBoxRepository.deleteAllByTable(tableEntity.getId());
         List<CustomizeTimeBox> timeBoxes = tableCreateRequest.toTimeBoxList();
         saveTimeBoxes(tableEntity, timeBoxes);
-        return CustomizeTableResponse.ofDomain(tableEntity.toDomain(), timeBoxes);
+        return new CustomizeTableResponse(tableEntity.toDomain(), timeBoxes);
     }
 
     @Transactional
@@ -72,7 +72,7 @@ public class CustomizeServiceV2 {
         tableEntity.updateUsedAt();
         CustomizeTable table = tableEntity.toDomain();
         List<CustomizeTimeBox> timeBoxes = timeBoxEntities.toDomain();
-        return CustomizeTableResponse.ofDomain(table, timeBoxes);
+        return new CustomizeTableResponse(table, timeBoxes);
     }
 
     @Transactional

--- a/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
@@ -2,12 +2,12 @@ package com.debatetimer.service.customize;
 
 import com.debatetimer.domain.customize.CustomizeTable;
 import com.debatetimer.domain.customize.CustomizeTimeBox;
-import com.debatetimer.domain.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.domain.member.Member;
 import com.debatetimer.dto.customize.request.CustomizeTableCreateRequest;
 import com.debatetimer.dto.customize.response.CustomizeTableResponse;
 import com.debatetimer.entity.customize.BellEntity;
 import com.debatetimer.entity.customize.CustomizeTableEntity;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntities;
 import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import com.debatetimer.repository.customize.BellRepository;
 import com.debatetimer.repository.customize.CustomizeTableRepository;

--- a/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeServiceV2.java
@@ -53,10 +53,10 @@ public class CustomizeServiceV2 {
             Member member
     ) {
         CustomizeTableEntity tableEntity = tableRepository.getByIdAndMember(tableId, member);
+        tableEntity.updateTable(tableCreateRequest.toTable(member));
+
         bellRepository.deleteAllByTable(tableEntity.getId());
         timeBoxRepository.deleteAllByTable(tableEntity.getId());
-
-        tableEntity.updateTable(tableCreateRequest.toTable(member));
         List<CustomizeTimeBox> timeBoxes = tableCreateRequest.toTimeBoxList();
         saveTimeBoxes(tableEntity, timeBoxes);
         return CustomizeTableResponse.ofDomain(tableEntity.toDomain(), timeBoxes);

--- a/src/test/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntitiesTest.java
+++ b/src/test/java/com/debatetimer/entity/customize/CustomizeTimeBoxEntitiesTest.java
@@ -1,10 +1,11 @@
-package com.debatetimer.domain.customize;
+package com.debatetimer.entity.customize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.debatetimer.domain.customize.CustomizeBoxType;
+import com.debatetimer.domain.customize.CustomizeTable;
+import com.debatetimer.domain.customize.Stance;
 import com.debatetimer.domain.member.Member;
-import com.debatetimer.entity.customize.CustomizeTableEntity;
-import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/com/debatetimer/repository/BaseRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/BaseRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.debatetimer.repository;
 
 import com.debatetimer.config.JpaAuditingConfig;
+import com.debatetimer.fixture.BellGenerator;
 import com.debatetimer.fixture.CustomizeTableGenerator;
 import com.debatetimer.fixture.CustomizeTimeBoxGenerator;
 import com.debatetimer.fixture.MemberGenerator;
@@ -12,7 +13,8 @@ import org.springframework.context.annotation.Import;
         JpaAuditingConfig.class,
         MemberGenerator.class,
         CustomizeTableGenerator.class,
-        CustomizeTimeBoxGenerator.class
+        CustomizeTimeBoxGenerator.class,
+        BellGenerator.class
 })
 @DataJpaTest
 public abstract class BaseRepositoryTest {
@@ -25,4 +27,7 @@ public abstract class BaseRepositoryTest {
 
     @Autowired
     protected CustomizeTimeBoxGenerator customizeTimeBoxGenerator;
+
+    @Autowired
+    protected BellGenerator bellGenerator;
 }

--- a/src/test/java/com/debatetimer/repository/customize/BellRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/customize/BellRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.debatetimer.repository.customize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.debatetimer.domain.customize.CustomizeBoxType;
+import com.debatetimer.domain.member.Member;
+import com.debatetimer.entity.customize.CustomizeTableEntity;
+import com.debatetimer.entity.customize.CustomizeTimeBoxEntity;
+import com.debatetimer.repository.BaseRepositoryTest;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class BellRepositoryTest extends BaseRepositoryTest {
+
+    @Autowired
+    private BellRepository bellRepository;
+
+    @Nested
+    class DeleteAllByTable {
+
+        @Test
+        void 특정_테이블에_해당하는_벨을_삭제한다() {
+            Member member = memberGenerator.generate("chan@gmail.com");
+            CustomizeTableEntity deleteBellTable = customizeTableGenerator.generate(member);
+            CustomizeTableEntity otherTable = customizeTableGenerator.generate(member);
+            CustomizeTimeBoxEntity deleteBellTimeBox = customizeTimeBoxGenerator.generate(deleteBellTable,
+                    CustomizeBoxType.NORMAL, 1);
+            CustomizeTimeBoxEntity otherTimeBox = customizeTimeBoxGenerator.generate(otherTable,
+                    CustomizeBoxType.NORMAL, 1);
+            bellGenerator.generate(deleteBellTimeBox, 45, 1);
+            bellGenerator.generate(deleteBellTimeBox, 60, 1);
+            bellGenerator.generate(otherTimeBox, 45, 1);
+
+            bellRepository.deleteAllByTable(deleteBellTable.getId());
+
+            assertAll(
+                    () -> assertThat(bellRepository.findAllByCustomizeTimeBoxIn(List.of(deleteBellTimeBox))).isEmpty(),
+                    () -> assertThat(bellRepository.findAllByCustomizeTimeBoxIn(List.of(otherTimeBox))).hasSize(1)
+            );
+
+        }
+    }
+
+}

--- a/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
+++ b/src/test/java/com/debatetimer/repository/customize/CustomizeTimeBoxRepositoryTest.java
@@ -48,7 +48,7 @@ class CustomizeTimeBoxRepositoryTest extends BaseRepositoryTest {
             customizeTimeBoxGenerator.generate(chanTable, CustomizeBoxType.NORMAL, 1);
             customizeTimeBoxGenerator.generate(chanTable, CustomizeBoxType.NORMAL, 2);
 
-            customizeTimeBoxRepository.deleteAllByTable(chanTable);
+            customizeTimeBoxRepository.deleteAllByTable(chanTable.getId());
 
             List<CustomizeTimeBoxEntity> timeBoxes = customizeTimeBoxRepository.findAllByCustomizeTable(chanTable);
             assertThat(timeBoxes).isEmpty();
@@ -63,7 +63,7 @@ class CustomizeTimeBoxRepositoryTest extends BaseRepositoryTest {
             CustomizeTableEntity deletedTable = customizeTableGenerator.generate(chan);
             customizeTimeBoxGenerator.generate(deletedTable, CustomizeBoxType.NORMAL, 1);
 
-            customizeTimeBoxRepository.deleteAllByTable(deletedTable);
+            customizeTimeBoxRepository.deleteAllByTable(deletedTable.getId());
 
             List<CustomizeTimeBoxEntity> timeBoxes = customizeTimeBoxRepository.findAllByCustomizeTable(filledTable);
             assertThat(timeBoxes).hasSize(2);
@@ -74,7 +74,7 @@ class CustomizeTimeBoxRepositoryTest extends BaseRepositoryTest {
             Member chan = memberGenerator.generate("default@gmail.com");
             CustomizeTableEntity emptyTable = customizeTableGenerator.generate(chan);
 
-            assertThatCode(() -> customizeTimeBoxRepository.deleteAllByTable(emptyTable))
+            assertThatCode(() -> customizeTimeBoxRepository.deleteAllByTable(emptyTable.getId()))
                     .doesNotThrowAnyException();
         }
     }

--- a/src/test/java/com/debatetimer/service/customize/CustomizeServiceV2Test.java
+++ b/src/test/java/com/debatetimer/service/customize/CustomizeServiceV2Test.java
@@ -80,7 +80,7 @@ class CustomizeServiceV2Test extends BaseServiceTest {
                     () -> assertThat(foundResponse.id()).isEqualTo(chanTable.getId()),
                     () -> assertThat(foundResponse.table()).hasSize(2),
                     () -> assertThat(foundResponse.table().get(0).bell()).hasSize(2),
-                    () -> assertThat(foundResponse.table().get(1).bell()).hasSize(0)
+                    () -> assertThat(foundResponse.table().get(1).bell()).isNull()
             );
         }
 


### PR DESCRIPTION
# 🚩 연관 이슈
closed #191 

# 🗣️ 리뷰 요구사항 (선택)
- 드디어 마지막 PR입니다. 리팩토링 시리즈 힘들었습니다.
- 이번에도 파일 15개 바뀌어서 커밋별 리뷰를 추천은 드립니다. (그래도 서비스 로직 개선 커밋은 보기 힘들수도;;)
- 논란의 PR이 될 수도? 금요일 회의에 API 변경 사항이 생길 것 같아 빠르게 끝냈습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 벨(Bell) 및 커스텀 타임박스(CustomizeTimeBox) 엔티티 간 변환 및 연관 관리 기능이 강화되었습니다.
  * 특정 테이블에 속한 벨을 일괄 삭제하는 기능이 추가되었습니다.

* **버그 수정**
  * 벨 및 타임박스 삭제 시 테이블 ID 기반으로 정확하게 삭제되도록 개선되었습니다.

* **리팩터링**
  * 도메인 중심의 엔티티 관리 방식으로 서비스 로직이 단순화되고 일관성 있게 변경되었습니다.
  * 불필요한 DTO 매핑 코드가 제거되었습니다.

* **테스트**
  * 벨 삭제 및 타임박스 삭제 동작을 검증하는 테스트가 추가 및 개선되었습니다.
  * 테스트 코드가 변경된 엔티티 구조에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->