### PR TITLE
[FEAT] 기관별 템플릿 조회 기능 구현

### DIFF
--- a/src/main/java/com/debatetimer/domain/organization/Organization.java
+++ b/src/main/java/com/debatetimer/domain/organization/Organization.java
@@ -1,0 +1,24 @@
+package com.debatetimer.domain.organization;
+
+import java.util.List;
+
+public class Organization {
+
+    private final Long id;
+    private final String name;
+    private final String affiliation;
+    private final String iconPath;
+    private final List<OrganizationTemplate> templates;
+
+    public Organization(Long id,
+                        String name,
+                        String affiliation,
+                        String iconPath,
+                        List<OrganizationTemplate> templates) {
+        this.id = id;
+        this.name = name;
+        this.affiliation = affiliation;
+        this.iconPath = iconPath;
+        this.templates = templates;
+    }
+}

--- a/src/main/java/com/debatetimer/domain/organization/Organization.java
+++ b/src/main/java/com/debatetimer/domain/organization/Organization.java
@@ -1,7 +1,9 @@
 package com.debatetimer.domain.organization;
 
 import java.util.List;
+import lombok.Getter;
 
+@Getter
 public class Organization {
 
     private final Long id;

--- a/src/main/java/com/debatetimer/domain/organization/OrganizationTemplate.java
+++ b/src/main/java/com/debatetimer/domain/organization/OrganizationTemplate.java
@@ -1,0 +1,17 @@
+package com.debatetimer.domain.organization;
+
+import lombok.Getter;
+
+@Getter
+public class OrganizationTemplate {
+
+    private final Long id;
+    private final String name;
+    private final String data;
+
+    public OrganizationTemplate(Long id, String name, String data) {
+        this.id = id;
+        this.name = name;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
+++ b/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
@@ -1,0 +1,37 @@
+package com.debatetimer.domainrepository.organization;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+import com.debatetimer.domain.organization.Organization;
+import com.debatetimer.domain.organization.OrganizationTemplate;
+import com.debatetimer.entity.organization.OrganizationTemplateEntity;
+import com.debatetimer.repository.organization.OrganizationRepository;
+import com.debatetimer.repository.organization.OrganizationTemplateRepository;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class OrganizationDomainRepository {
+
+    private final OrganizationRepository organizationRepository;
+    private final OrganizationTemplateRepository organizationTemplateDomainRepository;
+
+    public List<Organization> findAll() {
+        Map<Long, List<OrganizationTemplate>> idToTemplatesEntity = organizationTemplateDomainRepository.findAll()
+                .stream()
+                .collect(groupingBy(
+                        OrganizationTemplateEntity::getOrganizationId,
+                        mapping(OrganizationTemplateEntity::toDomain, toList()))
+                );
+
+        return organizationRepository.findAll()
+                .stream()
+                .map(entity -> entity.toDomain(idToTemplatesEntity.get(entity.getId())))
+                .toList();
+    }
+}

--- a/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
+++ b/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
@@ -9,6 +9,7 @@ import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.organization.OrganizationTemplateEntity;
 import com.debatetimer.repository.organization.OrganizationRepository;
 import com.debatetimer.repository.organization.OrganizationTemplateRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,10 @@ import org.springframework.stereotype.Repository;
 public class OrganizationDomainRepository {
 
     private final OrganizationRepository organizationRepository;
-    private final OrganizationTemplateRepository organizationTemplateDomainRepository;
+    private final OrganizationTemplateRepository organizationTemplateRepository;
 
     public List<Organization> findAll() {
-        Map<Long, List<OrganizationTemplate>> idToTemplatesEntity = organizationTemplateDomainRepository.findAll()
+        Map<Long, List<OrganizationTemplate>> idToTemplatesEntity = organizationTemplateRepository.findAll()
                 .stream()
                 .collect(groupingBy(
                         OrganizationTemplateEntity::getOrganizationId,
@@ -31,7 +32,8 @@ public class OrganizationDomainRepository {
 
         return organizationRepository.findAll()
                 .stream()
-                .map(entity -> entity.toDomain(idToTemplatesEntity.get(entity.getId())))
-                .toList();
+                .map(entity -> entity.toDomain(
+                        idToTemplatesEntity.getOrDefault(entity.getId(), Collections.emptyList()))
+                ).toList();
     }
 }

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
@@ -36,6 +36,12 @@ public class OrganizationEntity extends BaseTimeEntity {
     @NotBlank
     private String iconPath;
 
+    public OrganizationEntity(String name, String affiliation, String iconPath) {
+        this.name = name;
+        this.affiliation = affiliation;
+        this.iconPath = iconPath;
+    }
+
     public Organization toDomain(List<OrganizationTemplate> templates) {
         return new Organization(this.id, this.name, this.affiliation, this.iconPath, templates);
     }

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
@@ -1,0 +1,35 @@
+package com.debatetimer.entity.organization;
+
+import com.debatetimer.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "organization")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrganizationEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private String affiliation;
+
+    @Column(name = "icon_path")
+    @NotBlank
+    private String iconPath;
+}

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
@@ -3,7 +3,6 @@ package com.debatetimer.entity.organization;
 import com.debatetimer.domain.organization.Organization;
 import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -32,7 +31,6 @@ public class OrganizationEntity extends BaseTimeEntity {
     @NotNull
     private String affiliation;
 
-    @Column(name = "icon_path")
     @NotBlank
     private String iconPath;
 

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
@@ -1,5 +1,7 @@
 package com.debatetimer.entity.organization;
 
+import com.debatetimer.domain.organization.Organization;
+import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,4 +35,8 @@ public class OrganizationEntity extends BaseTimeEntity {
     @Column(name = "icon_path")
     @NotBlank
     private String iconPath;
+
+    public Organization toDomain(List<OrganizationTemplate> templates) {
+        return new Organization(this.id, this.name, this.affiliation, this.iconPath, templates);
+    }
 }

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
@@ -40,7 +40,17 @@ public class OrganizationTemplateEntity extends BaseTimeEntity {
     @Column(length = 8191)
     private String data;
 
+    public OrganizationTemplateEntity(OrganizationEntity organization, String name, String data) {
+        this.organization = organization;
+        this.name = name;
+        this.data = data;
+    }
+
     public OrganizationTemplate toDomain() {
         return new OrganizationTemplate(this.id, this.name, this.data);
+    }
+
+    public Long getOrganizationId() {
+        return this.organization.getId();
     }
 }

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
@@ -1,0 +1,41 @@
+package com.debatetimer.entity.organization;
+
+
+import com.debatetimer.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "organization_template")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrganizationTemplateEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id")
+    private OrganizationEntity organization;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Column(length = 8191)
+    private String data;
+}

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
@@ -1,6 +1,7 @@
 package com.debatetimer.entity.organization;
 
 
+import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,4 +39,8 @@ public class OrganizationTemplateEntity extends BaseTimeEntity {
     @NotBlank
     @Column(length = 8191)
     private String data;
+
+    public OrganizationTemplate toDomain() {
+        return new OrganizationTemplate(this.id, this.name, this.data);
+    }
 }

--- a/src/main/java/com/debatetimer/repository/organization/OrganizationRepository.java
+++ b/src/main/java/com/debatetimer/repository/organization/OrganizationRepository.java
@@ -1,0 +1,12 @@
+package com.debatetimer.repository.organization;
+
+import com.debatetimer.entity.organization.OrganizationEntity;
+import java.util.List;
+import org.springframework.data.repository.Repository;
+
+public interface OrganizationRepository extends Repository<OrganizationEntity, Long> {
+
+    List<OrganizationEntity> findAll();
+
+    OrganizationEntity save(OrganizationEntity organizationEntity);
+}

--- a/src/main/java/com/debatetimer/repository/organization/OrganizationTemplateRepository.java
+++ b/src/main/java/com/debatetimer/repository/organization/OrganizationTemplateRepository.java
@@ -1,0 +1,12 @@
+package com.debatetimer.repository.organization;
+
+import com.debatetimer.entity.organization.OrganizationTemplateEntity;
+import java.util.List;
+import org.springframework.data.repository.Repository;
+
+public interface OrganizationTemplateRepository extends Repository<OrganizationTemplateEntity, Long> {
+
+    List<OrganizationTemplateEntity> findAll();
+
+    OrganizationTemplateEntity save(OrganizationTemplateEntity entity);
+}

--- a/src/main/resources/db/migration/V15__create_organization_template.sql
+++ b/src/main/resources/db/migration/V15__create_organization_template.sql
@@ -1,0 +1,26 @@
+create table organization
+(
+    id          bigint auto_increment,
+    name        varchar(255) not null,
+    affiliation varchar(255) not null,
+    icon_path   varchar(255) not null,
+    created_at  timestamp    not null DEFAULT CURRENT_TIMESTAMP,
+    modified_at timestamp    not null DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    primary key (id)
+);
+
+create table organization_template
+(
+    id              bigint auto_increment,
+    name            varchar(255)  not null,
+    data            varchar(8191) not null,
+    organization_id bigint        not null,
+    created_at      timestamp     not null DEFAULT CURRENT_TIMESTAMP,
+    modified_at     timestamp     not null DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    primary key (id)
+);
+
+alter table organization_template
+    add constraint organization_template_to_organization
+        foreign key (organization_id)
+            references organization (id);

--- a/src/test/java/com/debatetimer/domainrepository/BaseDomainRepositoryTest.java
+++ b/src/test/java/com/debatetimer/domainrepository/BaseDomainRepositoryTest.java
@@ -8,6 +8,8 @@ import com.debatetimer.fixture.entity.BellEntityGenerator;
 import com.debatetimer.fixture.entity.CustomizeTableEntityGenerator;
 import com.debatetimer.fixture.entity.CustomizeTimeBoxEntityGenerator;
 import com.debatetimer.fixture.entity.MemberGenerator;
+import com.debatetimer.fixture.entity.OrganizationEntityGenerator;
+import com.debatetimer.fixture.entity.OrganizationTemplateEntityGenerator;
 import com.debatetimer.fixture.entity.PollEntityGenerator;
 import com.debatetimer.fixture.entity.VoteEntityGenerator;
 import com.debatetimer.repository.customize.BellRepository;
@@ -48,6 +50,12 @@ public abstract class BaseDomainRepositoryTest {
 
     @Autowired
     protected VoteEntityGenerator voteEntityGenerator;
+
+    @Autowired
+    protected OrganizationEntityGenerator organizationEntityGenerator;
+
+    @Autowired
+    protected OrganizationTemplateEntityGenerator organizationTemplateEntityGenerator;
 
     @Autowired
     protected PollRepository pollRepository;

--- a/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
+++ b/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.debatetimer.domainrepository.organization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.debatetimer.domain.organization.Organization;
+import com.debatetimer.domainrepository.BaseDomainRepositoryTest;
+import com.debatetimer.entity.organization.OrganizationEntity;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class OrganizationDomainRepositoryTest extends BaseDomainRepositoryTest {
+
+    @Autowired
+    private OrganizationDomainRepository organizationDomainRepository;
+
+    @Nested
+    class FindAll {
+
+        @Test
+        void 모든_조직_템플릿을_가져온다() {
+            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대");
+            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대");
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿1");
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿2");
+            organizationTemplateEntityGenerator.generate(organization2, "릿플템1");
+
+            List<Organization> organizations = organizationDomainRepository.findAll();
+
+            assertAll(
+                    () -> assertThat(organizations).hasSize(2),
+                    () -> assertThat(organizations.get(0).getTemplates()).hasSize(2),
+                    () -> assertThat(organizations.get(1).getTemplates()).hasSize(1)
+            );
+        }
+    }
+}

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
@@ -1,0 +1,22 @@
+package com.debatetimer.fixture.entity;
+
+import com.debatetimer.entity.organization.OrganizationEntity;
+import com.debatetimer.repository.organization.OrganizationRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrganizationEntityGenerator {
+
+    private static final String DEFAULT_ICON_PATH = "/static/icons/default_icon.png";
+
+    private final OrganizationRepository organizationRepository;
+
+    public OrganizationEntityGenerator(OrganizationRepository organizationRepository) {
+        this.organizationRepository = organizationRepository;
+    }
+
+    public OrganizationEntity generate(String name, String affiliation) {
+        OrganizationEntity organization = new OrganizationEntity(name, affiliation, DEFAULT_ICON_PATH);
+        return organizationRepository.save(organization);
+    }
+}

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
@@ -1,0 +1,24 @@
+package com.debatetimer.fixture.entity;
+
+import com.debatetimer.entity.organization.OrganizationEntity;
+import com.debatetimer.entity.organization.OrganizationTemplateEntity;
+import com.debatetimer.repository.organization.OrganizationTemplateRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrganizationTemplateEntityGenerator {
+
+    private static final String DEFAULT_TEMPLATE_CONTENT = "eJyrVspMUbIytjDXUcrMS8tXsqpWykvMTVWyUjJWKCtWMFZ427b1TXPj27YFrxcueN3T8HZWj8LbGVPfdM9V0lEqqSwAqXQODQ7x9%2FWMcgUKJaan5qUkAgWB7IKi%2FOKQ1MRcP4iBbzasedOyESienJ%2BHLP56wwygwUDx8sSivMy8dKfUnBwlq7TEnOJUHaW0zLzM4gwkoVqgtYlJOUCN0dVKxSWJeckgMwKC%2FIOBJhQXpKYmZ4RAnPVmXivQzUDRpPwKqJCff5Cvow%2FI5Zkgqw2NDICyYLPzSnNyIMIBqUUgx6EJBRekJmYDHQcTLgbxU4sg3FodJKc4%2B%2FsNFqf4uYaGBIEtQXPNhDdzFkCiFMVNIZ6%2BrvFOjsGuLnB3QazA6TBzkLMx3AX2DIkhtHXOm0WtCq83zHkzbQfdAwpr8qG7i2JrAbdLRw0%3D";
+
+    private final OrganizationTemplateRepository organizationTemplateRepository;
+
+    public OrganizationTemplateEntityGenerator(OrganizationTemplateRepository organizationTemplateRepository) {
+        this.organizationTemplateRepository = organizationTemplateRepository;
+    }
+
+    public OrganizationTemplateEntity generate(OrganizationEntity organization, String name) {
+        OrganizationTemplateEntity template =
+                new OrganizationTemplateEntity(organization, name, DEFAULT_TEMPLATE_CONTENT);
+        return organizationTemplateRepository.save(template);
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈
#222 

# PR 소개
### 구현 사항
- Organization, OrganizationTemplate 테이블 및 엔티티 구현
- Organization, OrganizationTemplate 도메인 객체 구현
- Organization, OrganizationTemplate 레포지토리, 도메인 레포지토리 구현 & 테스트

### 추후 구현 사항
- Organization, OrganizationTemplate 서비스 로직 구현 & 테스트
- Organization API 구현 & 테스트
- Organization, OrganizationTemplate 초기 데이터 작성
- Organization의 이미지 아이콘 추가

### 관련 문서 및 기타
- Tech Docs : https://www.notion.so/2a11550c60cf80f6b7ebf9ac008a6ec3
- 일단 절반 정도만 구현하고, 리뷰 받고 API 및 기타 작업 할께요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 조직 관리 기능 추가 (ID, 이름, 소속, 아이콘, 템플릿 포함)
  * 조직 템플릿(이름·내용) 도입 및 조직별 템플릿 연계 지원

* **데이터베이스**
  * 조직 및 조직 템플릿 테이블과 외래키 관계 추가

* **테스트**
  * 도메인 저장·조회 통합 테스트 및 테스트용 엔터티 생성기 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->