### PR TITLE
[Test] 시간 기반 테스트 수정

### DIFF
--- a/src/main/java/com/debatetimer/entity/BaseTimeEntity.java
+++ b/src/main/java/com/debatetimer/entity/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package com.debatetimer.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -21,4 +22,14 @@ public abstract class BaseTimeEntity {
     @NotNull
     @LastModifiedDate
     private LocalDateTime modifiedAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (modifiedAt == null) {
+            modifiedAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/debatetimer/entity/BaseTimeEntity.java
+++ b/src/main/java/com/debatetimer/entity/BaseTimeEntity.java
@@ -2,7 +2,6 @@ package com.debatetimer.entity;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -22,14 +21,4 @@ public abstract class BaseTimeEntity {
     @NotNull
     @LastModifiedDate
     private LocalDateTime modifiedAt;
-
-    @PrePersist
-    public void prePersist() {
-        if (createdAt == null) {
-            createdAt = LocalDateTime.now();
-        }
-        if (modifiedAt == null) {
-            modifiedAt = LocalDateTime.now();
-        }
-    }
 }

--- a/src/main/java/com/debatetimer/entity/customize/CustomizeTableEntity.java
+++ b/src/main/java/com/debatetimer/entity/customize/CustomizeTableEntity.java
@@ -60,7 +60,7 @@ public class CustomizeTableEntity extends BaseTimeEntity {
         this.consTeamName = customizeTable.getConsTeamName();
         this.warningBell = customizeTable.isWarningBell();
         this.finishBell = customizeTable.isFinishBell();
-        this.usedAt = LocalDateTime.now();
+        this.usedAt = customizeTable.getUsedAt();
     }
 
     public CustomizeTable toDomain() {

--- a/src/test/java/com/debatetimer/entity/customize/CustomizeTableEntityTest.java
+++ b/src/test/java/com/debatetimer/entity/customize/CustomizeTableEntityTest.java
@@ -30,7 +30,7 @@ class CustomizeTableEntityTest {
         void 테이블의_사용_시각을_업데이트한다() {
             Member member = new Member("default@gmail.com");
             CustomizeTable table = new CustomizeTable(member, "tableName", "agenda", "찬성", "반대",
-                    true, true, LocalDateTime.now().minusNanos(1L));
+                    true, true, LocalDateTime.now().minusSeconds(1L));
             CustomizeTableEntity customizeTableEntity = new CustomizeTableEntity(table);
             LocalDateTime beforeUsedAt = customizeTableEntity.getUsedAt();
 
@@ -68,7 +68,7 @@ class CustomizeTableEntityTest {
         void 테이블_업데이트_할_때_사용_시간을_변경한다() {
             Member member = new Member("default@gmail.com");
             CustomizeTable table = new CustomizeTable(member, "tableName", "agenda", "찬성", "반대",
-                    true, true, LocalDateTime.now().minusNanos(1L));
+                    true, true, LocalDateTime.now().minusSeconds(1L));
             CustomizeTableEntity customizeTableEntity = new CustomizeTableEntity(table);
             CustomizeTable renewTable = new CustomizeTable(member, "newName", "newAgenda",
                     "newPros", "newCons", false, false, LocalDateTime.now());


### PR DESCRIPTION
# 🚩 연관 이슈
closed #

# 🗣️ 리뷰 요구사항 (선택)
아래 글을 읽어주세요.

### 해당 테스트가 Mac에서 통과하는 이유 (by Gemini)
- Mac(macOS)은 전통적으로 시스템 클럭을 마이크로초(6자리, 0.000001초) 단위로 제공하는 경우가 많습니다.
- 현재 시간: ...10.123456000 (Mac은 뒤 3자리를 0으로 줌)
- Java 로직 (minusNanos(1)): ...10.123455999 (9자리로 계산됨)
- H2 저장 (6자리로 잘림):
  - 원본: ...10.123456
  - 변경: ...10.123455 (마지막 999가 잘려나감)
- 비교: 123456 vs 123455 -> 다르다! (테스트 통과 ✅)

### 윈도우에서 해당 테스트가 통과하지 않는 이유 (by Gemini)
- 최신 Windows는 시스템 클럭을 나노초(9자리, 0.000000001초) 단위까지 꽉 채워서 제공합니다.
- 현재 시간: ...10.123456789 (9자리 꽉 참)
- Java 로직 (minusNanos(1)): ...10.123456788
- H2 저장 (6자리로 잘림):
  - 원본: ...10.123456 (뒤 789 버림)
  - 변경: ...10.123456 (뒤 788 버림)
- 비교: 123456 vs 123456 -> 같다! (테스트 실패 ❌)

그래서 1초 차이로 테스트에 반영하도록 수정했습니다. 추가적인 리뷰 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **타임스탠프 초기화 동작 조정** - 엔티티 생성 시 타임스탠프 초기화 방식이 변경되었습니다. 테스트 정확성 개선으로 타임스탠프 검증이 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->