### PR TITLE
[CHORE] 팀이름 최대 길이를 15자로 수정

### DIFF
--- a/src/main/java/com/debatetimer/domain/customize/TeamName.java
+++ b/src/main/java/com/debatetimer/domain/customize/TeamName.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public class TeamName {
 
     private static final String NAME_REGEX = "^[\\p{L}\\p{M}\\p{N}\\p{P}\\p{Z}\\s]+$";
-    public static final int NAME_MAX_LENGTH = 8;
+    public static final int NAME_MAX_LENGTH = 15;
 
     private final String value;
 


### PR DESCRIPTION
# 🚩 연관 이슈
closed #238 

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 팀 이름 입력 가능 길이가 8자에서 15자로 확대되어, 더 긴 팀 이름을 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->