### PR TITLE
[FEAT] 비회원용 테이블정보 조회 메서드 추가

### DIFF
--- a/src/main/java/com/debatetimer/controller/customize/CustomizeController.java
+++ b/src/main/java/com/debatetimer/controller/customize/CustomizeController.java
@@ -39,7 +39,7 @@ public class CustomizeController {
             @PathVariable Long tableId,
             @AuthMember Member member
     ) {
-        return customizeService.findTable(tableId, member);
+        return customizeService.findMemberTable(tableId, member);
     }
 
     @PutMapping("/api/table/customize/{tableId}")

--- a/src/main/java/com/debatetimer/controller/sharing/SharingRestController.java
+++ b/src/main/java/com/debatetimer/controller/sharing/SharingRestController.java
@@ -3,11 +3,14 @@ package com.debatetimer.controller.sharing;
 import com.debatetimer.controller.auth.AuthMember;
 import com.debatetimer.controller.tool.jwt.AuthManager;
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.dto.customize.response.CustomizeTableResponse;
 import com.debatetimer.dto.sharing.response.ChairmanTokenResponse;
 import com.debatetimer.service.customize.CustomizeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,5 +28,13 @@ public class SharingRestController {
         long debateTime = customizeService.findDebateTime(tableId, member);
         String chairmanToken = authManager.issueChairmanToken(member, debateTime * 2);
         return new ChairmanTokenResponse(chairmanToken);
+    }
+
+    @GetMapping("/api/live/table/customize/{tableId}")
+    @ResponseStatus(HttpStatus.OK)
+    public CustomizeTableResponse getTable(
+            @PathVariable long tableId
+    ) {
+        return customizeService.findTable(tableId);
     }
 }

--- a/src/main/java/com/debatetimer/domainrepository/customize/CustomizeTableDomainRepository.java
+++ b/src/main/java/com/debatetimer/domainrepository/customize/CustomizeTableDomainRepository.java
@@ -54,8 +54,22 @@ public class CustomizeTableDomainRepository {
     }
 
     @Transactional(readOnly = true)
-    public List<CustomizeTimeBox> getCustomizeTimeBoxes(long tableId, Member member) {
+    public CustomizeTable getById(long tableId) {
+        return tableRepository.getById(tableId)
+                .toDomain();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CustomizeTimeBox> getMemberCustomizeTimeBoxes(long tableId, Member member) {
         CustomizeTableEntity tableEntity = tableRepository.getByIdAndMember(tableId, member);
+        List<CustomizeTimeBoxEntity> timeBoxEntityList = timeBoxRepository.findAllByCustomizeTable(tableEntity);
+        List<BellEntity> bellEntityList = bellRepository.findAllByCustomizeTimeBoxIn(timeBoxEntityList);
+        return toCustomizeTimeBoxes(timeBoxEntityList, bellEntityList);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CustomizeTimeBox> getCustomizeTimeBoxes(long tableId) {
+        CustomizeTableEntity tableEntity = tableRepository.getById(tableId);
         List<CustomizeTimeBoxEntity> timeBoxEntityList = timeBoxRepository.findAllByCustomizeTable(tableEntity);
         List<BellEntity> bellEntityList = bellRepository.findAllByCustomizeTimeBoxIn(timeBoxEntityList);
         return toCustomizeTimeBoxes(timeBoxEntityList, bellEntityList);

--- a/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
+++ b/src/main/java/com/debatetimer/repository/customize/CustomizeTableRepository.java
@@ -23,5 +23,10 @@ public interface CustomizeTableRepository extends Repository<CustomizeTableEntit
                 .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
     }
 
+    default CustomizeTableEntity getById(long tableId) {
+        return findById(tableId)
+                .orElseThrow(() -> new DTClientErrorException(ClientErrorCode.TABLE_NOT_FOUND));
+    }
+
     void delete(CustomizeTableEntity table);
 }

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -28,7 +28,14 @@ public class CustomizeService {
     @Transactional(readOnly = true)
     public CustomizeTableResponse findMemberTable(long tableId, Member member) {
         CustomizeTable table = customizeTableDomainRepository.getByIdAndMember(tableId, member);
-        List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(tableId, member);
+        List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getMemberCustomizeTimeBoxes(tableId, member);
+        return new CustomizeTableResponse(table, timeBoxes);
+    }
+
+    @Transactional(readOnly = true)
+    public CustomizeTableResponse findTable(long tableId) {
+        CustomizeTable table = customizeTableDomainRepository.getById(tableId);
+        List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(tableId);
         return new CustomizeTableResponse(table, timeBoxes);
     }
 
@@ -54,7 +61,7 @@ public class CustomizeService {
     @Transactional
     public CustomizeTableResponse updateUsedAt(long tableId, Member member) {
         CustomizeTable table = customizeTableDomainRepository.updateUsedAt(tableId, member);
-        List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(tableId, member);
+        List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getMemberCustomizeTimeBoxes(tableId, member);
         return new CustomizeTableResponse(table, timeBoxes);
     }
 

--- a/src/main/java/com/debatetimer/service/customize/CustomizeService.java
+++ b/src/main/java/com/debatetimer/service/customize/CustomizeService.java
@@ -26,7 +26,7 @@ public class CustomizeService {
     }
 
     @Transactional(readOnly = true)
-    public CustomizeTableResponse findTable(long tableId, Member member) {
+    public CustomizeTableResponse findMemberTable(long tableId, Member member) {
         CustomizeTable table = customizeTableDomainRepository.getByIdAndMember(tableId, member);
         List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(tableId, member);
         return new CustomizeTableResponse(table, timeBoxes);

--- a/src/test/java/com/debatetimer/controller/customize/CustomizeDocumentTest.java
+++ b/src/test/java/com/debatetimer/controller/customize/CustomizeDocumentTest.java
@@ -263,7 +263,7 @@ public class CustomizeDocumentTest extends BaseDocumentTest {
                                     null, null, 360, null, null)
                     )
             );
-            doReturn(response).when(customizeService).findTable(eq(tableId), any());
+            doReturn(response).when(customizeService).findMemberTable(eq(tableId), any());
 
             var document = document("customize/get", 200)
                     .request(requestDocument)
@@ -282,7 +282,7 @@ public class CustomizeDocumentTest extends BaseDocumentTest {
         @EnumSource(value = ClientErrorCode.class, names = {"TABLE_NOT_FOUND"})
         void 사용자_지정_테이블_조회_실패(ClientErrorCode errorCode) {
             long tableId = 5L;
-            doThrow(new DTClientErrorException(errorCode)).when(customizeService).findTable(eq(tableId), any());
+            doThrow(new DTClientErrorException(errorCode)).when(customizeService).findMemberTable(eq(tableId), any());
 
             var document = document("customize/get", errorCode)
                     .request(requestDocument)

--- a/src/test/java/com/debatetimer/controller/sharing/SharingDocumentTest.java
+++ b/src/test/java/com/debatetimer/controller/sharing/SharingDocumentTest.java
@@ -3,7 +3,12 @@ package com.debatetimer.controller.sharing;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -12,10 +17,23 @@ import com.debatetimer.controller.BaseDocumentTest;
 import com.debatetimer.controller.RestDocumentationRequest;
 import com.debatetimer.controller.RestDocumentationResponse;
 import com.debatetimer.controller.Tag;
+import com.debatetimer.domain.customize.BellType;
+import com.debatetimer.domain.customize.CustomizeBoxType;
+import com.debatetimer.domain.customize.Stance;
 import com.debatetimer.domain.member.Member;
+import com.debatetimer.dto.customize.response.BellResponse;
+import com.debatetimer.dto.customize.response.CustomizeTableInfoResponse;
+import com.debatetimer.dto.customize.response.CustomizeTableResponse;
+import com.debatetimer.dto.customize.response.CustomizeTimeBoxResponse;
+import com.debatetimer.dto.member.TableType;
+import com.debatetimer.exception.custom.DTClientErrorException;
+import com.debatetimer.exception.errorcode.ClientErrorCode;
 import io.restassured.http.ContentType;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.http.HttpHeaders;
 
 public class SharingDocumentTest extends BaseDocumentTest {
@@ -54,6 +72,100 @@ public class SharingDocumentTest extends BaseDocumentTest {
                     .pathParam("tableId", String.valueOf(requestTableId))
                     .when().get("/api/live/{tableId}/chairman-token")
                     .then().statusCode(200);
+        }
+    }
+
+    @Nested
+    class GetTable {
+
+        private final RestDocumentationRequest requestDocument = request()
+                .tag(Tag.SHARING_API)
+                .summary("비회원용 사용자 지정 토론 시간표 조회")
+                .description("""
+                        ### 타임 박스 종류에 따른 웅답 값
+                        | 타임 박스 종류 | 필수 입력 | 선택 입력 | null 입력 |
+                        | :---: | ---| --- | --- |
+                        | 커스텀 타임 박스 | stance, speechType, boxType, time | speaker | timePerTeam, timePerSpeaking |
+                        | 자유 토론 타임 박스 | stance, speechType, boxType, timePerTeam | speaker, timePerSpeaking | time |
+                        """)
+                .pathParameter(
+                        parameterWithName("tableId").description("테이블 ID")
+                );
+
+        private final RestDocumentationResponse responseDocument = response()
+                .responseBodyField(
+                        fieldWithPath("id").type(NUMBER).description("테이블 ID"),
+                        fieldWithPath("info").type(OBJECT).description("토론 테이블 정보"),
+                        fieldWithPath("info.name").type(STRING).description("테이블 이름"),
+                        fieldWithPath("info.agenda").type(STRING).description("토론 주제"),
+                        fieldWithPath("info.type").type(STRING).description("토론 테이블 유형"),
+                        fieldWithPath("info.prosTeamName").type(STRING).description("찬성팀 팀명"),
+                        fieldWithPath("info.consTeamName").type(STRING).description("반대팀 팀명"),
+                        fieldWithPath("info.warningBell").type(BOOLEAN).description("30초 종소리 유무"),
+                        fieldWithPath("info.finishBell").type(BOOLEAN).description("발언 종료 종소리 유무"),
+                        fieldWithPath("table").type(ARRAY).description("토론 테이블 구성"),
+                        fieldWithPath("table[].stance").type(STRING).description("입장"),
+                        fieldWithPath("table[].speechType").type(STRING).description("발언 유형"),
+                        fieldWithPath("table[].boxType").type(STRING).description("타임 박스 유형"),
+                        fieldWithPath("table[].time").type(NUMBER).description("발언 시간(초)").optional(),
+                        fieldWithPath("table[].bell").type(ARRAY).description("종소리 정보").optional(),
+                        fieldWithPath("table[].bell[].type").type(STRING).description("종소리 종류"),
+                        fieldWithPath("table[].bell[].time").type(NUMBER).description("종소리 울릴 시간(초)"),
+                        fieldWithPath("table[].bell[].count").type(NUMBER).description("종소리 횟수"),
+                        fieldWithPath("table[].timePerTeam").type(NUMBER).description("팀당 발언 시간 (초)").optional(),
+                        fieldWithPath("table[].timePerSpeaking").type(NUMBER).description("1회 발언 시간 (초)").optional(),
+                        fieldWithPath("table[].speaker").type(STRING).description("발언자 이름").optional()
+                );
+
+        @Test
+        void 비회원_사용자_지정_테이블_조회_성공() {
+            long tableId = 5L;
+            CustomizeTableResponse response = new CustomizeTableResponse(
+                    5L,
+                    new CustomizeTableInfoResponse("나의 테이블", TableType.CUSTOMIZE, "토론 주제",
+                            "찬성", "반대", true, true),
+                    List.of(
+                            new CustomizeTimeBoxResponse(Stance.PROS, "입론", CustomizeBoxType.NORMAL,
+                                    120, List.of(new BellResponse(BellType.AFTER_START, 90, 1)), null, null, "콜리"),
+                            new CustomizeTimeBoxResponse(Stance.CONS, "입론", CustomizeBoxType.NORMAL,
+                                    120, List.of(new BellResponse(BellType.AFTER_START, 90, 1),
+                                    new BellResponse(BellType.AFTER_START, 120, 2)), null, null, "비토"),
+                            new CustomizeTimeBoxResponse(Stance.NEUTRAL, "난상 토론", CustomizeBoxType.TIME_BASED,
+                                    null, null, 360, 120, null),
+                            new CustomizeTimeBoxResponse(Stance.NEUTRAL, "존중 토론", CustomizeBoxType.TIME_BASED,
+                                    null, null, 360, null, null)
+                    )
+            );
+            doReturn(response).when(customizeService).findTable(eq(tableId));
+
+            var document = document("sharing/get_table", 200)
+                    .request(requestDocument)
+                    .response(responseDocument)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .pathParam("tableId", tableId)
+                    .when().get("/api/live/table/customize/{tableId}")
+                    .then().statusCode(200);
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = ClientErrorCode.class, names = {"TABLE_NOT_FOUND"})
+        void 비회원_사용자_지정_테이블_조회_실패(ClientErrorCode errorCode) {
+            long tableId = 5L;
+            doThrow(new DTClientErrorException(errorCode)).when(customizeService).findTable(eq(tableId));
+
+            var document = document("sharing/get_table", errorCode)
+                    .request(requestDocument)
+                    .response(ERROR_RESPONSE)
+                    .build();
+
+            given(document)
+                    .contentType(ContentType.JSON)
+                    .pathParam("tableId", tableId)
+                    .when().get("/api/live/table/customize/{tableId}")
+                    .then().statusCode(errorCode.getStatus().value());
         }
     }
 }

--- a/src/test/java/com/debatetimer/controller/sharing/SharingRestControllerTest.java
+++ b/src/test/java/com/debatetimer/controller/sharing/SharingRestControllerTest.java
@@ -1,0 +1,51 @@
+package com.debatetimer.controller.sharing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.debatetimer.controller.BaseControllerTest;
+import com.debatetimer.domain.customize.CustomizeBoxType;
+import com.debatetimer.domain.member.Member;
+import com.debatetimer.dto.customize.response.CustomizeTableResponse;
+import com.debatetimer.entity.customize.CustomizeTableEntity;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SharingRestControllerTest extends BaseControllerTest {
+
+    @Nested
+    class GetTable {
+
+        @Test
+        void 비회원이_사용자_지정_테이블을_조회한다() {
+            Member bito = memberGenerator.generate("default@gmail.com");
+            CustomizeTableEntity bitoTable = customizeTableEntityGenerator.generate(bito);
+            customizeTimeBoxEntityGenerator.generate(bitoTable, CustomizeBoxType.NORMAL, 1);
+            customizeTimeBoxEntityGenerator.generateNotExistSpeaker(bitoTable, CustomizeBoxType.NORMAL, 2);
+
+            CustomizeTableResponse response = given()
+                    .contentType(ContentType.JSON)
+                    .pathParam("tableId", bitoTable.getId())
+                    .when().get("/api/live/table/customize/{tableId}")
+                    .then().statusCode(200)
+                    .extract().as(CustomizeTableResponse.class);
+
+            assertAll(
+                    () -> assertThat(response.id()).isEqualTo(bitoTable.getId()),
+                    () -> assertThat(response.table()).hasSize(2)
+            );
+        }
+
+        @Test
+        void 존재하지_않는_테이블을_조회하면_예외가_발생한다() {
+            long notExistTableId = 999L;
+
+            given()
+                    .contentType(ContentType.JSON)
+                    .pathParam("tableId", notExistTableId)
+                    .when().get("/api/live/table/customize/{tableId}")
+                    .then().statusCode(404);
+        }
+    }
+}

--- a/src/test/java/com/debatetimer/domainrepository/customize/CustomizeTableDomainRepositoryTest.java
+++ b/src/test/java/com/debatetimer/domainrepository/customize/CustomizeTableDomainRepositoryTest.java
@@ -75,7 +75,7 @@ class CustomizeTableDomainRepositoryTest extends BaseDomainRepositoryTest {
             timeBoxEntityGenerator.generate(tableEntity, CustomizeBoxType.NORMAL, 2, 180);
             timeBoxEntityGenerator.generate(tableEntity, CustomizeBoxType.NORMAL, 3, 120);
 
-            List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(
+            List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getMemberCustomizeTimeBoxes(
                     tableEntity.getId(), member);
 
             assertThat(timeBoxes).hasSize(3)
@@ -95,7 +95,7 @@ class CustomizeTableDomainRepositoryTest extends BaseDomainRepositoryTest {
             bellEntityGenerator.generate(timeBoxEntity1, BellType.BEFORE_END, 30, 1);
             bellEntityGenerator.generate(timeBoxEntity2, BellType.BEFORE_END, 10, 1);
 
-            List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getCustomizeTimeBoxes(
+            List<CustomizeTimeBox> timeBoxes = customizeTableDomainRepository.getMemberCustomizeTimeBoxes(
                     tableEntity.getId(), member);
 
             assertAll(

--- a/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
+++ b/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
@@ -100,6 +100,39 @@ class CustomizeServiceTest extends BaseServiceTest {
     }
 
     @Nested
+    class FindTableForGuest {
+
+        @Test
+        void 비회원이_사용자_지정_토론_테이블을_조회한다() {
+            Member chan = memberGenerator.generate("default@gmail.com");
+            CustomizeTableEntity chanTable = customizeTableEntityGenerator.generate(chan);
+            CustomizeTimeBoxEntity customizeTimeBox = customizeTimeBoxEntityGenerator.generate(
+                    chanTable, CustomizeBoxType.NORMAL, 1);
+            customizeTimeBoxEntityGenerator.generate(chanTable, CustomizeBoxType.NORMAL, 2);
+            bellEntityGenerator.generate(customizeTimeBox, BellType.AFTER_START, 1, 1);
+            bellEntityGenerator.generate(customizeTimeBox, BellType.AFTER_START, 1, 2);
+
+            CustomizeTableResponse foundResponse = customizeService.findTable(chanTable.getId());
+
+            assertAll(
+                    () -> assertThat(foundResponse.id()).isEqualTo(chanTable.getId()),
+                    () -> assertThat(foundResponse.table()).hasSize(2),
+                    () -> assertThat(foundResponse.table().get(0).bell()).hasSize(2),
+                    () -> assertThat(foundResponse.table().get(1).bell()).isNull()
+            );
+        }
+
+        @Test
+        void 존재하지_않는_테이블_조회_시_예외를_발생시킨다() {
+            long notExistTableId = 999L;
+
+            assertThatThrownBy(() -> customizeService.findTable(notExistTableId))
+                    .isInstanceOf(DTClientErrorException.class)
+                    .hasMessage(ClientErrorCode.TABLE_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
     class FindDebateTime {
 
         @Test

--- a/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
+++ b/src/test/java/com/debatetimer/service/customize/CustomizeServiceTest.java
@@ -76,7 +76,7 @@ class CustomizeServiceTest extends BaseServiceTest {
             bellEntityGenerator.generate(customizeTimeBox, BellType.AFTER_START, 1, 1);
             bellEntityGenerator.generate(customizeTimeBox, BellType.AFTER_START, 1, 2);
 
-            CustomizeTableResponse foundResponse = customizeService.findTable(chanTable.getId(), chan);
+            CustomizeTableResponse foundResponse = customizeService.findMemberTable(chanTable.getId(), chan);
 
             assertAll(
                     () -> assertThat(foundResponse.id()).isEqualTo(chanTable.getId()),
@@ -93,7 +93,7 @@ class CustomizeServiceTest extends BaseServiceTest {
             CustomizeTableEntity chanTable = customizeTableEntityGenerator.generate(chan);
             long chanTableId = chanTable.getId();
 
-            assertThatThrownBy(() -> customizeService.findTable(chanTableId, coli))
+            assertThatThrownBy(() -> customizeService.findMemberTable(chanTableId, coli))
                     .isInstanceOf(DTClientErrorException.class)
                     .hasMessage(ClientErrorCode.TABLE_NOT_FOUND.getMessage());
         }


### PR DESCRIPTION
# 🚩 연관 이슈
closed #256 

# 🗣️ 리뷰 요구사항 (선택)

웹소켓 통신과정에서 비회원의 경우에도 토론 테이블 정보를 조회하기 위한 Rest API가 필요해져 이를 추가합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 지정된 테이블을 조회하는 새 공개 API가 추가되었습니다.
  * 조회 결과로 사용자 지정 테이블 정보와 시간박스 목록을 반환합니다.

* **Bug Fixes**
  * 테이블 조회 시 존재하지 않는 ID에 대해 적절한 오류가 반환되도록 개선했습니다.
  * 회원 기준 조회와 비회원 기준 조회 경로를 분리해 응답 일관성을 높였습니다.

* **Tests**
  * 새 조회 API와 기존 조회 흐름에 대한 테스트 및 문서 검증이 추가/갱신되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->