### PR TITLE
[FEAT] 글로벌 템플릿을 위한 기관/기관템플릿에 language 필드 추가

### DIFF
--- a/src/main/java/com/debatetimer/controller/organization/OrganizationController.java
+++ b/src/main/java/com/debatetimer/controller/organization/OrganizationController.java
@@ -1,10 +1,12 @@
 package com.debatetimer.controller.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.dto.organization.OrganizationResponses;
 import com.debatetimer.service.organization.OrganizationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,7 +16,8 @@ public class OrganizationController {
     private final OrganizationService organizationService;
 
     @GetMapping("/api/organizations/templates")
-    public ResponseEntity<OrganizationResponses> getOrganizationTemplates() {
-        return ResponseEntity.ok(organizationService.findAll());
+    public ResponseEntity<OrganizationResponses> getOrganizationTemplates(
+            @RequestParam(defaultValue = "KR") Language language) {
+        return ResponseEntity.ok(organizationService.findAll(language));
     }
 }

--- a/src/main/java/com/debatetimer/controller/organization/OrganizationController.java
+++ b/src/main/java/com/debatetimer/controller/organization/OrganizationController.java
@@ -17,7 +17,7 @@ public class OrganizationController {
 
     @GetMapping("/api/organizations/templates")
     public ResponseEntity<OrganizationResponses> getOrganizationTemplates(
-            @RequestParam(defaultValue = "KR") Language language) {
+            @RequestParam(defaultValue = "KO_KR") Language language) {
         return ResponseEntity.ok(organizationService.findAll(language));
     }
 }

--- a/src/main/java/com/debatetimer/domain/organization/Language.java
+++ b/src/main/java/com/debatetimer/domain/organization/Language.java
@@ -1,0 +1,7 @@
+package com.debatetimer.domain.organization;
+
+public enum Language {
+    EN,
+    KR,
+    ;
+}

--- a/src/main/java/com/debatetimer/domain/organization/Language.java
+++ b/src/main/java/com/debatetimer/domain/organization/Language.java
@@ -1,7 +1,7 @@
 package com.debatetimer.domain.organization;
 
 public enum Language {
-    EN,
-    KR,
+    US_EN,
+    KO_KR,
     ;
 }

--- a/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
+++ b/src/main/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepository.java
@@ -1,5 +1,6 @@
 package com.debatetimer.domainrepository.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.domain.organization.Organization;
 import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.organization.OrganizationTemplateEntity;
@@ -19,15 +20,15 @@ public class OrganizationDomainRepository {
     private final OrganizationRepository organizationRepository;
     private final OrganizationTemplateRepository organizationTemplateRepository;
 
-    public List<Organization> findAll() {
-        Map<Long, List<OrganizationTemplate>> idToTemplatesEntity = organizationTemplateRepository.findAll()
+    public List<Organization> findAllByLanguage(Language language) {
+        Map<Long, List<OrganizationTemplate>> idToTemplatesEntity = organizationTemplateRepository.findAllByLanguage(language)
                 .stream()
                 .collect(Collectors.groupingBy(
                         OrganizationTemplateEntity::getOrganizationId,
                         Collectors.mapping(OrganizationTemplateEntity::toDomain, Collectors.toList())
                 ));
 
-        return organizationRepository.findAll()
+        return organizationRepository.findAllByLanguage(language)
                 .stream()
                 .map(entity -> entity.toDomain(
                         idToTemplatesEntity.getOrDefault(entity.getId(), Collections.emptyList())

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationEntity.java
@@ -1,9 +1,12 @@
 package com.debatetimer.entity.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.domain.organization.Organization;
 import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,10 +37,15 @@ public class OrganizationEntity extends BaseTimeEntity {
     @NotBlank
     private String iconPath;
 
-    public OrganizationEntity(String name, String affiliation, String iconPath) {
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Language language;
+
+    public OrganizationEntity(String name, String affiliation, String iconPath, Language language) {
         this.name = name;
         this.affiliation = affiliation;
         this.iconPath = iconPath;
+        this.language = language;
     }
 
     public Organization toDomain(List<OrganizationTemplate> templates) {

--- a/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
+++ b/src/main/java/com/debatetimer/entity/organization/OrganizationTemplateEntity.java
@@ -1,10 +1,13 @@
 package com.debatetimer.entity.organization;
 
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.domain.organization.OrganizationTemplate;
 import com.debatetimer.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -40,10 +43,15 @@ public class OrganizationTemplateEntity extends BaseTimeEntity {
     @Column(length = 8191)
     private String data;
 
-    public OrganizationTemplateEntity(OrganizationEntity organization, String name, String data) {
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private Language language;
+
+    public OrganizationTemplateEntity(OrganizationEntity organization, String name, String data, Language language) {
         this.organization = organization;
         this.name = name;
         this.data = data;
+        this.language = language;
     }
 
     public OrganizationTemplate toDomain() {

--- a/src/main/java/com/debatetimer/repository/organization/OrganizationRepository.java
+++ b/src/main/java/com/debatetimer/repository/organization/OrganizationRepository.java
@@ -1,12 +1,13 @@
 package com.debatetimer.repository.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.entity.organization.OrganizationEntity;
 import java.util.List;
 import org.springframework.data.repository.Repository;
 
 public interface OrganizationRepository extends Repository<OrganizationEntity, Long> {
 
-    List<OrganizationEntity> findAll();
+    List<OrganizationEntity> findAllByLanguage(Language language);
 
     OrganizationEntity save(OrganizationEntity organizationEntity);
 }

--- a/src/main/java/com/debatetimer/repository/organization/OrganizationTemplateRepository.java
+++ b/src/main/java/com/debatetimer/repository/organization/OrganizationTemplateRepository.java
@@ -1,12 +1,13 @@
 package com.debatetimer.repository.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.entity.organization.OrganizationTemplateEntity;
 import java.util.List;
 import org.springframework.data.repository.Repository;
 
 public interface OrganizationTemplateRepository extends Repository<OrganizationTemplateEntity, Long> {
 
-    List<OrganizationTemplateEntity> findAll();
+    List<OrganizationTemplateEntity> findAllByLanguage(Language language);
 
     OrganizationTemplateEntity save(OrganizationTemplateEntity entity);
 }

--- a/src/main/java/com/debatetimer/service/organization/OrganizationService.java
+++ b/src/main/java/com/debatetimer/service/organization/OrganizationService.java
@@ -1,5 +1,6 @@
 package com.debatetimer.service.organization;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.domainrepository.organization.OrganizationDomainRepository;
 import com.debatetimer.dto.organization.OrganizationResponses;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,7 @@ public class OrganizationService {
 
     private final OrganizationDomainRepository organizationDomainRepository;
 
-    public OrganizationResponses findAll() {
-        return OrganizationResponses.from(organizationDomainRepository.findAll());
+    public OrganizationResponses findAll(Language language) {
+        return OrganizationResponses.from(organizationDomainRepository.findAllByLanguage(language));
     }
 }

--- a/src/main/resources/db/migration/V16__add_language_into_organization.sql
+++ b/src/main/resources/db/migration/V16__add_language_into_organization.sql
@@ -1,0 +1,13 @@
+alter table organization
+    add column language varchar(255) null;
+update organization
+set language = 'KR';
+alter table organization
+    modify column language varchar(255) not null;
+
+alter table organization_template
+    add column language varchar(255) null;
+update organization_template
+set language = 'KR';
+alter table organization_template
+    modify column language varchar(255) not null;

--- a/src/main/resources/db/migration/V16__add_language_into_organization.sql
+++ b/src/main/resources/db/migration/V16__add_language_into_organization.sql
@@ -1,13 +1,5 @@
 alter table organization
-    add column language varchar(255) null;
-update organization
-set language = 'KR';
-alter table organization
-    modify column language varchar(255) not null;
+    add column language varchar(255) not null default 'KO_KR';
 
 alter table organization_template
-    add column language varchar(255) null;
-update organization_template
-set language = 'KR';
-alter table organization_template
-    modify column language varchar(255) not null;
+    add column language varchar(255) not null default 'KO_KR';

--- a/src/main/resources/db/migration/V16__add_language_into_organization.sql
+++ b/src/main/resources/db/migration/V16__add_language_into_organization.sql
@@ -1,13 +1,5 @@
 alter table organization
-    add column language varchar(255) null;
-update organization
-set language = 'KR';
-alter table organization
-    modify column language varchar(255) not null;
+    add column language varchar(255) not null;
 
 alter table organization_template
-    add column language varchar(255) null;
-update organization_template
-set language = 'KR';
-alter table organization_template
-    modify column language varchar(255) not null;
+    add column language varchar(255) not null;

--- a/src/test/java/com/debatetimer/controller/organization/OrganizationControllerTest.java
+++ b/src/test/java/com/debatetimer/controller/organization/OrganizationControllerTest.java
@@ -19,13 +19,13 @@ class OrganizationControllerTest extends BaseControllerTest {
 
         @Test
         void language_파라미터가_없으면_KR_기관의_토론_템플릿을_조회한다() {
-            OrganizationEntity korean1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
-            OrganizationEntity korean2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KR);
-            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
-            organizationTemplateEntityGenerator.generate(korean1, "템플릿1", Language.KR);
-            organizationTemplateEntityGenerator.generate(korean1, "템플릿2", Language.KR);
-            organizationTemplateEntityGenerator.generate(korean2, "릿플템1", Language.KR);
-            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
+            OrganizationEntity korean1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KO_KR);
+            OrganizationEntity korean2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KO_KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(korean1, "템플릿1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(korean1, "템플릿2", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(korean2, "릿플템1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.US_EN);
 
             OrganizationResponses response = given()
                     .contentType(ContentType.JSON)
@@ -42,15 +42,15 @@ class OrganizationControllerTest extends BaseControllerTest {
 
         @Test
         void 요청한_언어의_기관_토론_템플릿만_조회한다() {
-            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
-            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
-            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
-            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
-            organizationTemplateEntityGenerator.generate(english, "template2", Language.EN);
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KO_KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(english, "template2", Language.US_EN);
 
             OrganizationResponses response = given()
                     .contentType(ContentType.JSON)
-                    .queryParam("language", "EN")
+                    .queryParam("language", "US_EN")
                     .when().get("/api/organizations/templates")
                     .then().statusCode(HttpStatus.OK.value())
                     .extract().as(OrganizationResponses.class);

--- a/src/test/java/com/debatetimer/controller/organization/OrganizationControllerTest.java
+++ b/src/test/java/com/debatetimer/controller/organization/OrganizationControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.debatetimer.controller.BaseControllerTest;
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.dto.organization.OrganizationResponses;
 import com.debatetimer.entity.organization.OrganizationEntity;
 import io.restassured.http.ContentType;
@@ -17,12 +18,14 @@ class OrganizationControllerTest extends BaseControllerTest {
     class GetOrganizationTemplates {
 
         @Test
-        void 모든_기관의_토론_템플릿을_조회할_수_있다() {
-            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대");
-            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대");
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿1");
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿2");
-            organizationTemplateEntityGenerator.generate(organization2, "릿플템1");
+        void language_파라미터가_없으면_KR_기관의_토론_템플릿을_조회한다() {
+            OrganizationEntity korean1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
+            OrganizationEntity korean2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
+            organizationTemplateEntityGenerator.generate(korean1, "템플릿1", Language.KR);
+            organizationTemplateEntityGenerator.generate(korean1, "템플릿2", Language.KR);
+            organizationTemplateEntityGenerator.generate(korean2, "릿플템1", Language.KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
 
             OrganizationResponses response = given()
                     .contentType(ContentType.JSON)
@@ -35,6 +38,37 @@ class OrganizationControllerTest extends BaseControllerTest {
                     () -> assertThat(response.organizations().get(0).templates()).hasSize(2),
                     () -> assertThat(response.organizations().get(1).templates()).hasSize(1)
             );
+        }
+
+        @Test
+        void 요청한_언어의_기관_토론_템플릿만_조회한다() {
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
+            organizationTemplateEntityGenerator.generate(english, "template2", Language.EN);
+
+            OrganizationResponses response = given()
+                    .contentType(ContentType.JSON)
+                    .queryParam("language", "EN")
+                    .when().get("/api/organizations/templates")
+                    .then().statusCode(HttpStatus.OK.value())
+                    .extract().as(OrganizationResponses.class);
+
+            assertAll(
+                    () -> assertThat(response.organizations()).hasSize(1),
+                    () -> assertThat(response.organizations().get(0).organization()).isEqualTo("english"),
+                    () -> assertThat(response.organizations().get(0).templates()).hasSize(2)
+            );
+        }
+
+        @Test
+        void 지원하지_않는_언어를_요청하면_400을_반환한다() {
+            given()
+                    .contentType(ContentType.JSON)
+                    .queryParam("language", "JP")
+                    .when().get("/api/organizations/templates")
+                    .then().statusCode(HttpStatus.BAD_REQUEST.value());
         }
     }
 }

--- a/src/test/java/com/debatetimer/controller/organization/OrganizationDocumentTest.java
+++ b/src/test/java/com/debatetimer/controller/organization/OrganizationDocumentTest.java
@@ -29,7 +29,7 @@ public class OrganizationDocumentTest extends BaseDocumentTest {
                 .summary("기관별 템플릿 조회")
                 .queryParameter(
                         parameterWithName("language").optional()
-                                .description("조회 언어 (EN | KR, 기본값 KR)")
+                                .description("조회 언어 (US_EN | KO_KR, 기본값 KO_KR)")
                 );
 
         private final RestDocumentationResponse responseDocument = response()
@@ -66,7 +66,7 @@ public class OrganizationDocumentTest extends BaseDocumentTest {
 
             given(document)
                     .contentType(ContentType.JSON)
-                    .queryParam("language", "KR")
+                    .queryParam("language", "KO_KR")
                     .when().get("/api/organizations/templates")
                     .then().statusCode(200);
         }

--- a/src/test/java/com/debatetimer/controller/organization/OrganizationDocumentTest.java
+++ b/src/test/java/com/debatetimer/controller/organization/OrganizationDocumentTest.java
@@ -1,9 +1,11 @@
 package com.debatetimer.controller.organization;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
 import com.debatetimer.controller.BaseDocumentTest;
 import com.debatetimer.controller.RestDocumentationRequest;
@@ -24,7 +26,11 @@ public class OrganizationDocumentTest extends BaseDocumentTest {
 
         private final RestDocumentationRequest requestDocument = request()
                 .tag(Tag.ORGANIZATION_API)
-                .summary("기관별 템플릿 조회");
+                .summary("기관별 템플릿 조회")
+                .queryParameter(
+                        parameterWithName("language").optional()
+                                .description("조회 언어 (EN | KR, 기본값 KR)")
+                );
 
         private final RestDocumentationResponse responseDocument = response()
                 .responseBodyField(
@@ -51,7 +57,7 @@ public class OrganizationDocumentTest extends BaseDocumentTest {
                             new OrganizationTemplateResponse("템플릿2", DEFAULT_TEMPLATE_CONTENT)
                     ))
             ));
-            doReturn(response).when(organizationService).findAll();
+            doReturn(response).when(organizationService).findAll(any());
 
             var document = document("organization/get-templates", 200)
                     .request(requestDocument)
@@ -60,6 +66,7 @@ public class OrganizationDocumentTest extends BaseDocumentTest {
 
             given(document)
                     .contentType(ContentType.JSON)
+                    .queryParam("language", "KR")
                     .when().get("/api/organizations/templates")
                     .then().statusCode(200);
         }

--- a/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
+++ b/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
@@ -3,6 +3,7 @@ package com.debatetimer.domainrepository.organization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.domain.organization.Organization;
 import com.debatetimer.domainrepository.BaseDomainRepositoryTest;
 import com.debatetimer.entity.organization.OrganizationEntity;
@@ -17,22 +18,39 @@ class OrganizationDomainRepositoryTest extends BaseDomainRepositoryTest {
     private OrganizationDomainRepository organizationDomainRepository;
 
     @Nested
-    class FindAll {
+    class FindAllByLanguage {
 
         @Test
-        void 모든_조직_템플릿을_가져온다() {
-            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대");
-            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대");
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿1");
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿2");
-            organizationTemplateEntityGenerator.generate(organization2, "릿플템1");
+        void 해당_언어의_모든_조직_템플릿을_가져온다() {
+            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
+            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KR);
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿1", Language.KR);
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿2", Language.KR);
+            organizationTemplateEntityGenerator.generate(organization2, "릿플템1", Language.KR);
 
-            List<Organization> organizations = organizationDomainRepository.findAll();
+            List<Organization> organizations = organizationDomainRepository.findAllByLanguage(Language.KR);
 
             assertAll(
                     () -> assertThat(organizations).hasSize(2),
                     () -> assertThat(organizations.get(0).getTemplates()).hasSize(2),
                     () -> assertThat(organizations.get(1).getTemplates()).hasSize(1)
+            );
+        }
+
+        @Test
+        void 요청한_언어의_조직_템플릿만_반환한다() {
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
+            organizationTemplateEntityGenerator.generate(english, "template2", Language.EN);
+
+            List<Organization> englishOrganizations = organizationDomainRepository.findAllByLanguage(Language.EN);
+
+            assertAll(
+                    () -> assertThat(englishOrganizations).hasSize(1),
+                    () -> assertThat(englishOrganizations.get(0).getName()).isEqualTo("english"),
+                    () -> assertThat(englishOrganizations.get(0).getTemplates()).hasSize(2)
             );
         }
     }

--- a/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
+++ b/src/test/java/com/debatetimer/domainrepository/organization/OrganizationDomainRepositoryTest.java
@@ -22,13 +22,13 @@ class OrganizationDomainRepositoryTest extends BaseDomainRepositoryTest {
 
         @Test
         void 해당_언어의_모든_조직_템플릿을_가져온다() {
-            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
-            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KR);
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿1", Language.KR);
-            organizationTemplateEntityGenerator.generate(organization1, "템플릿2", Language.KR);
-            organizationTemplateEntityGenerator.generate(organization2, "릿플템1", Language.KR);
+            OrganizationEntity organization1 = organizationEntityGenerator.generate("한앎", "한양대", Language.KO_KR);
+            OrganizationEntity organization2 = organizationEntityGenerator.generate("한모름", "양한대", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(organization1, "템플릿2", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(organization2, "릿플템1", Language.KO_KR);
 
-            List<Organization> organizations = organizationDomainRepository.findAllByLanguage(Language.KR);
+            List<Organization> organizations = organizationDomainRepository.findAllByLanguage(Language.KO_KR);
 
             assertAll(
                     () -> assertThat(organizations).hasSize(2),
@@ -39,13 +39,13 @@ class OrganizationDomainRepositoryTest extends BaseDomainRepositoryTest {
 
         @Test
         void 요청한_언어의_조직_템플릿만_반환한다() {
-            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
-            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
-            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
-            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
-            organizationTemplateEntityGenerator.generate(english, "template2", Language.EN);
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KO_KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(english, "template2", Language.US_EN);
 
-            List<Organization> englishOrganizations = organizationDomainRepository.findAllByLanguage(Language.EN);
+            List<Organization> englishOrganizations = organizationDomainRepository.findAllByLanguage(Language.US_EN);
 
             assertAll(
                     () -> assertThat(englishOrganizations).hasSize(1),

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
@@ -1,5 +1,6 @@
 package com.debatetimer.fixture.entity;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.entity.organization.OrganizationEntity;
 import com.debatetimer.repository.organization.OrganizationRepository;
 import org.springframework.stereotype.Component;
@@ -16,7 +17,11 @@ public class OrganizationEntityGenerator {
     }
 
     public OrganizationEntity generate(String name, String affiliation) {
-        OrganizationEntity organization = new OrganizationEntity(name, affiliation, DEFAULT_ICON_PATH);
+        return generate(name, affiliation, Language.KR);
+    }
+
+    public OrganizationEntity generate(String name, String affiliation, Language language) {
+        OrganizationEntity organization = new OrganizationEntity(name, affiliation, DEFAULT_ICON_PATH, language);
         return organizationRepository.save(organization);
     }
 }

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationEntityGenerator.java
@@ -17,7 +17,7 @@ public class OrganizationEntityGenerator {
     }
 
     public OrganizationEntity generate(String name, String affiliation) {
-        return generate(name, affiliation, Language.KR);
+        return generate(name, affiliation, Language.KO_KR);
     }
 
     public OrganizationEntity generate(String name, String affiliation, Language language) {

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
@@ -1,5 +1,6 @@
 package com.debatetimer.fixture.entity;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.entity.organization.OrganizationEntity;
 import com.debatetimer.entity.organization.OrganizationTemplateEntity;
 import com.debatetimer.repository.organization.OrganizationTemplateRepository;
@@ -17,8 +18,12 @@ public class OrganizationTemplateEntityGenerator {
     }
 
     public OrganizationTemplateEntity generate(OrganizationEntity organization, String name) {
+        return generate(organization, name, Language.KR);
+    }
+
+    public OrganizationTemplateEntity generate(OrganizationEntity organization, String name, Language language) {
         OrganizationTemplateEntity template =
-                new OrganizationTemplateEntity(organization, name, DEFAULT_TEMPLATE_CONTENT);
+                new OrganizationTemplateEntity(organization, name, DEFAULT_TEMPLATE_CONTENT, language);
         return organizationTemplateRepository.save(template);
     }
 }

--- a/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
+++ b/src/test/java/com/debatetimer/fixture/entity/OrganizationTemplateEntityGenerator.java
@@ -18,7 +18,7 @@ public class OrganizationTemplateEntityGenerator {
     }
 
     public OrganizationTemplateEntity generate(OrganizationEntity organization, String name) {
-        return generate(organization, name, Language.KR);
+        return generate(organization, name, Language.KO_KR);
     }
 
     public OrganizationTemplateEntity generate(OrganizationEntity organization, String name, Language language) {

--- a/src/test/java/com/debatetimer/service/organization/OrganizationServiceTest.java
+++ b/src/test/java/com/debatetimer/service/organization/OrganizationServiceTest.java
@@ -3,6 +3,7 @@ package com.debatetimer.service.organization;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.debatetimer.domain.organization.Language;
 import com.debatetimer.dto.organization.OrganizationResponses;
 import com.debatetimer.entity.organization.OrganizationEntity;
 import com.debatetimer.service.BaseServiceTest;
@@ -26,7 +27,7 @@ class OrganizationServiceTest extends BaseServiceTest {
             organizationTemplateEntityGenerator.generate(organization1, "템플릿2");
             organizationTemplateEntityGenerator.generate(organization2, "릿플템1");
 
-            OrganizationResponses response = organizationService.findAll();
+            OrganizationResponses response = organizationService.findAll(Language.KR);
 
             assertAll(
                     () -> assertThat(response.organizations()).hasSize(2),
@@ -36,8 +37,23 @@ class OrganizationServiceTest extends BaseServiceTest {
         }
 
         @Test
+        void 요청한_언어의_기관_템플릿만_반환한다() {
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
+
+            OrganizationResponses response = organizationService.findAll(Language.EN);
+
+            assertAll(
+                    () -> assertThat(response.organizations()).hasSize(1),
+                    () -> assertThat(response.organizations().get(0).organization()).isEqualTo("english")
+            );
+        }
+
+        @Test
         void 비어있을_경우_빈_객체를_반환한다() {
-            OrganizationResponses response = organizationService.findAll();
+            OrganizationResponses response = organizationService.findAll(Language.KR);
 
             assertThat(response.organizations()).isEmpty();
         }

--- a/src/test/java/com/debatetimer/service/organization/OrganizationServiceTest.java
+++ b/src/test/java/com/debatetimer/service/organization/OrganizationServiceTest.java
@@ -27,7 +27,7 @@ class OrganizationServiceTest extends BaseServiceTest {
             organizationTemplateEntityGenerator.generate(organization1, "템플릿2");
             organizationTemplateEntityGenerator.generate(organization2, "릿플템1");
 
-            OrganizationResponses response = organizationService.findAll(Language.KR);
+            OrganizationResponses response = organizationService.findAll(Language.KO_KR);
 
             assertAll(
                     () -> assertThat(response.organizations()).hasSize(2),
@@ -38,12 +38,12 @@ class OrganizationServiceTest extends BaseServiceTest {
 
         @Test
         void 요청한_언어의_기관_템플릿만_반환한다() {
-            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KR);
-            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.EN);
-            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KR);
-            organizationTemplateEntityGenerator.generate(english, "template1", Language.EN);
+            OrganizationEntity korean = organizationEntityGenerator.generate("한앎", "한양대", Language.KO_KR);
+            OrganizationEntity english = organizationEntityGenerator.generate("english", "hanyang", Language.US_EN);
+            organizationTemplateEntityGenerator.generate(korean, "템플릿1", Language.KO_KR);
+            organizationTemplateEntityGenerator.generate(english, "template1", Language.US_EN);
 
-            OrganizationResponses response = organizationService.findAll(Language.EN);
+            OrganizationResponses response = organizationService.findAll(Language.US_EN);
 
             assertAll(
                     () -> assertThat(response.organizations()).hasSize(1),
@@ -53,7 +53,7 @@ class OrganizationServiceTest extends BaseServiceTest {
 
         @Test
         void 비어있을_경우_빈_객체를_반환한다() {
-            OrganizationResponses response = organizationService.findAll(Language.KR);
+            OrganizationResponses response = organizationService.findAll(Language.KO_KR);
 
             assertThat(response.organizations()).isEmpty();
         }


### PR DESCRIPTION
# 🚩 연관 이슈
closed #258 

# 🗣️ 리뷰 요구사항 (선택)

- 현재 템플릿은 한국어 버전에서만 제공할 예정임 (중앙선거방통위, 한양대, 경희대, 고려대 등등)
- 영어 버전에서는 니즈에 맞게 링컨 더글라스, CEDA 등 더 보편적인 글로벌 템플릿으로 제공할 예정
- 이를 위해 language 필드를 추가해 언어별로 기관/기관 템플릿을 조회할 수 있도록 합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 기관 템플릿을 언어별로 조회할 수 있습니다(한국어(KO_KR), 영어(US_EN)).
  - 언어를 지정하지 않으면 기본값인 한국어(KO_KR)로 조회됩니다.
  - 지원하지 않는 언어 요청 시 400 오류가 반환됩니다.
- **문서**
  - 템플릿 조회 API 문서에 선택적 언어 파라미터와 지원 범위를 반영했습니다.
- **테스트**
  - 기본/영어/지원하지 않는 언어 시나리오에 대한 검증을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->